### PR TITLE
support increment and decrement for gauge

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,31 @@ just before `prometheus::collect()` to return a real-time value.
 * `value` is a value that the gauge should be set to. Required.
 * `label_values` is an array of label values.
 
+### gauge:inc()
+
+**syntax:** gauge:inc(*value*, *label_values*)
+
+Increments or decrements a previously registered gauge. This is usually called 
+when you want to observe the real-time value of a metric that can both be 
+increased and decreased.
+
+* `value` is a value that should be added to the gauge. It could be a negative 
+value when you need to decrease the value of the gauge. Defaults to 1.
+* `label_values` is an array of label values.
+
+The number of label values should match the number of label names defined when
+the gauge was registered using `prometheus:gauge()`. No label values should
+be provided for gauges with no labels. Non-printable characters will be
+stripped from label values.
+
+Example:
+```
+init_worker_by_lua '
+  metric_bytes:inc(tonumber(ngx.var.request_length))
+  metric_requests:inc(1, {ngx.var.server_name, ngx.var.status})
+';
+```
+
 ### histogram:observe()
 
 **syntax:** histogram:observe(*value*, *label_values*)

--- a/README.md
+++ b/README.md
@@ -274,14 +274,6 @@ the gauge was registered using `prometheus:gauge()`. No label values should
 be provided for gauges with no labels. Non-printable characters will be
 stripped from label values.
 
-Example:
-```
-init_worker_by_lua '
-  metric_bytes:inc(tonumber(ngx.var.request_length))
-  metric_requests:inc(1, {ngx.var.server_name, ngx.var.status})
-';
-```
-
 ### histogram:observe()
 
 **syntax:** histogram:observe(*value*, *label_values*)

--- a/prometheus.lua
+++ b/prometheus.lua
@@ -124,7 +124,8 @@ end
 -- Increase a given gauge by `value`
 --
 -- Args:
---   value: (number) a value to add to the gauge (a negative value when you need to decrease the value of the gauge). Defaults to 1 if skipped.
+--   value: (number) a value to add to the gauge (a negative value when you
+--     need to decrease the value of the gauge). Defaults to 1 if skipped.
 --   label_values: an array of label values. Can be nil (i.e. not defined) for
 --     metrics that have no labels.
 function Gauge:inc(value, label_values)
@@ -444,7 +445,8 @@ end
 --   name: (string) short metric name without any labels.
 --   label_names: (array) a list of label keys.
 --   label_values: (array) a list of label values.
---   value: (number) value to add (a negative value when you need to decrease the value of the gauge). Optional, defaults to 1.
+--   value: (number) value to add (a negative value when you need to decrease
+--     the value of the gauge). Optional, defaults to 1.
 function Prometheus:inc(name, label_names, label_values, value)
   local key = full_metric_name(name, label_names, label_values)
   if value == nil then value = 1 end

--- a/prometheus.lua
+++ b/prometheus.lua
@@ -505,11 +505,11 @@ function Prometheus:dec(name, label_names, label_values, value)
   -- Hopefully this does not happen too often (shared dictionary does not get
   -- reset during configuation reload).
   if err == "not found" then
-    self:set_key(key, value)
+    self:set_key(key, 0 - value)
     return
   end
   -- Unexpected error
-  self:log_error_kv(key, value, err)
+  self:log_error_kv(key, 0 - value, err)
 end
 
 -- Set the current value of a gauge to `value`

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -243,7 +243,7 @@ function TestPrometheus:testGaugeIncDec()
   self.gauge2:dec(20, {"f2value", "f1value"})
   luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), -18)
   luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 4)
-  
+
   self.gauge1:inc(1, {"should-be-no-labels"})
   self.gauge1:dec(1, {"should-be-no-labels"})
   self.gauge2:inc(1, {"too-few-labels"})
@@ -251,6 +251,12 @@ function TestPrometheus:testGaugeIncDec()
   luaunit.assertEquals(self.dict:get("gauge1"), -1)
   luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), -18)
   luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 8)
+
+
+  self.gauge2:dec(1, {"f2value", "f1value_new"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value_new"}'), -1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 8)
+
 
 end
 function TestPrometheus:testLatencyHistogram()

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -190,6 +190,60 @@ function TestPrometheus:testCounters()
   luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="v1"}'), 4)
   luaunit.assertEquals(ngx.logs, nil)
 end
+function TestPrometheus:testGaugeIncDec()
+  self.gauge1:inc(-1)
+  luaunit.assertEquals(self.dict:get("gauge1"), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+
+  self.gauge1:inc(3)
+  luaunit.assertEquals(self.dict:get("gauge1"), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+
+  self.gauge1:inc()
+  luaunit.assertEquals(self.dict:get("gauge1"), 4)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+
+  self.gauge1:dec()
+  luaunit.assertEquals(self.dict:get("gauge1"), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+
+  self.gauge1:dec(-1)
+  luaunit.assertEquals(self.dict:get("gauge1"), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 2)
+
+  self.gauge1:dec(2)
+  luaunit.assertEquals(self.dict:get("gauge1"), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 2)
+
+  self.gauge1:dec(2)
+  luaunit.assertEquals(self.dict:get("gauge1"), -1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 2)
+
+  self.gauge2:inc(-1, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 3)
+
+  self.gauge2:inc(5, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 5)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="othervalue"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 3)
+
+  self.gauge2:dec(1, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 4)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 3)
+
+  self.gauge2:dec(-1, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 4)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 4)
+
+  self.gauge2:dec(2, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 2)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 4)
+
+  self.gauge2:dec(20, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), -18)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 4)
+end
 function TestPrometheus:testLatencyHistogram()
   self.hist1:observe(0.35)
   self.hist1:observe(0.4)

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -243,6 +243,15 @@ function TestPrometheus:testGaugeIncDec()
   self.gauge2:dec(20, {"f2value", "f1value"})
   luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), -18)
   luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 4)
+  
+  self.gauge1:inc(1, {"should-be-no-labels"})
+  self.gauge1:dec(1, {"should-be-no-labels"})
+  self.gauge2:inc(1, {"too-few-labels"})
+  self.gauge2:dec(1, {"too-few-labels"})
+  luaunit.assertEquals(self.dict:get("gauge1"), -1)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), -18)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 8)
+
 end
 function TestPrometheus:testLatencyHistogram()
   self.hist1:observe(0.35)

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -193,72 +193,39 @@ function TestPrometheus:testCounters()
 end
 function TestPrometheus:testGaugeIncDec()
   self.gauge1:inc(-1)
-  luaunit.assertEquals(self.dict:get("gauge1"), nil)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+  luaunit.assertEquals(self.dict:get("gauge1"), -1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
 
   self.gauge1:inc(3)
-  luaunit.assertEquals(self.dict:get("gauge1"), 3)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+  luaunit.assertEquals(self.dict:get("gauge1"), 2)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
 
   self.gauge1:inc()
-  luaunit.assertEquals(self.dict:get("gauge1"), 4)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
-
-  self.gauge1:dec()
   luaunit.assertEquals(self.dict:get("gauge1"), 3)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
 
-  self.gauge1:dec(-1)
-  luaunit.assertEquals(self.dict:get("gauge1"), 3)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 2)
-
-  self.gauge1:dec(2)
-  luaunit.assertEquals(self.dict:get("gauge1"), 1)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 2)
-
-  self.gauge1:dec(2)
-  luaunit.assertEquals(self.dict:get("gauge1"), -1)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 2)
-
-  self.gauge2:inc(-1, {"f2value", "f1value"})
-  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), nil)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 3)
+  self.gauge2:inc(1, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
 
   self.gauge2:inc(5, {"f2value", "f1value"})
-  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 5)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 6)
   luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="othervalue"}'), nil)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
 
-  self.gauge2:dec(1, {"f2value", "f1value"})
+  self.gauge2:inc(-2, {"f2value", "f1value"})
   luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 4)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
 
-  self.gauge2:dec(-1, {"f2value", "f1value"})
-  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 4)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 4)
-
-  self.gauge2:dec(2, {"f2value", "f1value"})
-  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 2)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 4)
-
-  self.gauge2:dec(20, {"f2value", "f1value"})
-  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), -18)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 4)
+  self.gauge2:inc(-5, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), -1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
 
   self.gauge1:inc(1, {"should-be-no-labels"})
-  self.gauge1:dec(1, {"should-be-no-labels"})
   self.gauge2:inc(1, {"too-few-labels"})
-  self.gauge2:dec(1, {"too-few-labels"})
-  luaunit.assertEquals(self.dict:get("gauge1"), -1)
-  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), -18)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 8)
-
-
-  self.gauge2:dec(1, {"f2value", "f1value_new"})
-  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value_new"}'), -1)
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 8)
-
-
+  luaunit.assertEquals(self.dict:get("gauge1"), 3)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), -1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 2)
 end
 function TestPrometheus:testLatencyHistogram()
   self.hist1:observe(0.35)

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -78,8 +78,9 @@ function TestPrometheus:testErrorUnitialized()
   p:counter("metric1")
   p:histogram("metric2")
   p:gauge("metric3")
+  p:metric_data()
 
-  luaunit.assertEquals(#ngx.logs, 3)
+  luaunit.assertEquals(#ngx.logs, 4)
 end
 function TestPrometheus:testErrorUnknownDict()
   local p = prometheus.init("nonexistent")


### PR DESCRIPTION
Recently we having doing some Stats jobs in lua via prometheus and we use this library.  For some reasons we want to know the number of  currently running threads of nginx (ngx_lua), so the "decrement" is necessary when a thread is finished and exited.  The Prometheus library in Golang is supporting increment and decrement for gauge:

[gaugo.go](https://github.com/prometheus/client_golang/blob/master/prometheus/gauge.go)
```
type Gauge interface {
	Metric
	Collector

	// Set sets the Gauge to an arbitrary value.
	Set(float64)
	// Inc increments the Gauge by 1. Use Add to increment it by arbitrary
	// values.
	Inc()
	// Dec decrements the Gauge by 1. Use Sub to decrement it by arbitrary
	// values.
	Dec()
	// Add adds the given value to the Gauge. (The value can be negative,
	// resulting in a decrease of the Gauge.)
	Add(float64)
	// Sub subtracts the given value from the Gauge. (The value can be
	// negative, resulting in an increase of the Gauge.)
	Sub(float64)

	// SetToCurrentTime sets the Gauge to the current Unix time in seconds.
	SetToCurrentTime()
}
```

So, I think it's quite practical for gauge to support increment and decrement in lua too, which we have already applied to our system.
