### PR TITLE
Support del and reset for gauge and counter

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,31 @@ log_by_lua '
 ';
 ```
 
+### counter:del()
+
+**syntax:** counter:del(*label_values*)
+
+Delete a previously registered counter. This is usually called when you don't 
+need to observe such counter (or a metric with specific label values in this 
+counter) any more. If this counter has labels, you have to pass `label_values` 
+to delete the specific metric of this counter. If you want to delete all the 
+metrics of a counter with labels, you should call `Counter:reset()`.
+
+* `label_values` is an array of label values.
+
+The number of label values should match the number of label names defined when
+the counter was registered using `prometheus:counter()`. No label values should
+be provided for counters with no labels. Non-printable characters will be
+stripped from label values.
+
+### counter:reset()
+
+**syntax:** counter:reset()
+
+Delete all metrics for a previously registered counter. If this counter have no 
+labels, it is just the same as `Counter:del()` function. If this counter have labels, 
+it will delete all the metrics with different label values.
+
 ### gauge:set()
 
 **syntax:** gauge:set(*value*, *label_values*)
@@ -273,6 +298,31 @@ The number of label values should match the number of label names defined when
 the gauge was registered using `prometheus:gauge()`. No label values should
 be provided for gauges with no labels. Non-printable characters will be
 stripped from label values.
+
+### gauge:del()
+
+**syntax:** gauge:del(*label_values*)
+
+Delete a previously registered gauge. This is usually called when you don't 
+need to observe such gauge (or a metric with specific label values in this 
+gauge) any more. If this gauge has labels, you have to pass `label_values` 
+to delete the specific metric of this gauge. If you want to delete all the 
+metrics of a gauge with labels, you should call `Gauge:reset()`.
+
+* `label_values` is an array of label values.
+
+The number of label values should match the number of label names defined when
+the gauge was registered using `prometheus:gauge()`. No label values should
+be provided for gauges with no labels. Non-printable characters will be
+stripped from label values.
+
+### gauge:reset()
+
+**syntax:** gauge:reset()
+
+Delete all metrics for a previously registered gauge. If this gauge have no 
+labels, it is just the same as `Gauge:del()` function. If this gauge have labels, 
+it will delete all the metrics with different label values.
 
 ### histogram:observe()
 

--- a/prometheus.lua
+++ b/prometheus.lua
@@ -552,18 +552,9 @@ function Prometheus:histogram_observe(name, label_names, label_values, value)
   end
 end
 
-
+-- Delete all metrics in a gauge or counter. If this gauge or counter have labels, it
+--   will delete all the metrics with different label values.
 function Prometheus:reset(name)
-  if self.registered[name] ~= true then
-    self:log_error("Metric[" .. name .. "] is not registered")
-    return
-  end
-
-  if self.type[name] ~= "gauge" and self.type[name] ~= "counter" then
-    self:log_error("Only gauge and counter can reset")
-    return
-  end
-
   local keys = self.dict:get_keys(0)
   for _, key in ipairs(keys) do
     local value, err = self.dict:get(key)

--- a/prometheus.lua
+++ b/prometheus.lua
@@ -100,10 +100,26 @@ function Counter:inc(value, label_values)
   self.prometheus:inc(self.name, self.label_names, label_values, value or 1)
 end
 
+-- Delete a given counter
+--
+-- Args:
+--   label_values: an array of label values. Can be nil (i.e. not defined) for
+--     metrics that have no labels.
+function Counter:del(label_values)
+  local err = self:check_label_values(label_values)
+  if err ~= nil then
+    self.prometheus:log_error(err)
+    return
+  end
+  self.prometheus:set(self.name, self.label_names, label_values, nil)
+end
+
+-- Delete all metrics for this counter. If this counter have no labels, it is
+--   just the same as Counter:del() function. If this counter have labels, it
+--   will delete all the metrics with different label values.
 function Counter:reset()
   self.prometheus:reset(self.name)
 end
-
 
 local Gauge = Metric:new()
 -- Set a given gauge to `value`
@@ -125,7 +141,11 @@ function Gauge:set(value, label_values)
   self.prometheus:set(self.name, self.label_names, label_values, value)
 end
 
-
+-- Delete a given gauge
+--
+-- Args:
+--   label_values: an array of label values. Can be nil (i.e. not defined) for
+--     metrics that have no labels.
 function Gauge:del(label_values)
   local err = self:check_label_values(label_values)
   if err ~= nil then
@@ -135,11 +155,12 @@ function Gauge:del(label_values)
   self.prometheus:set(self.name, self.label_names, label_values, nil)
 end
 
-
+-- Delete all metrics for this gauge. If this gauge have no labels, it is
+--   just the same as Gauge:del() function. If this gauge have labels, it
+--   will delete all the metrics with different label values.
 function Gauge:reset()
   self.prometheus:reset(self.name)
 end
-
 
 -- Increase a given gauge by `value`
 --
@@ -408,7 +429,6 @@ function Prometheus:gauge(name, description, label_names)
 
   return Gauge:new{name=name, label_names=label_names, prometheus=self}
 end
-
 
 -- Register a histogram.
 --

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -23,6 +23,10 @@ function SimpleDict:incr(k, v)
   return self.dict[k], nil  -- newval, err
 end
 function SimpleDict:get(k)
+  -- simulate an error
+  if k == "gauge2{f2=\"dict_error\",f1=\"dict_error\"}" then
+    return nil, 0
+  end
   return self.dict[k], 0  -- value, flags
 end
 function SimpleDict:get_keys(k)
@@ -323,6 +327,12 @@ function TestPrometheus:testReset()
   luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
   luaunit.assertEquals(self.dict:get("gauge1"), 3)
   luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  -- error get from dict
+  self.gauge2:inc(4, {"dict_error", "dict_error"})
+  self.gauge2:reset()
+  luaunit.assertEquals(self.dict:get('gauge2{f2="dict_error",f1="dict_error"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
 end
 function TestPrometheus:testLatencyHistogram()
   self.hist1:observe(0.35)

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -227,6 +227,79 @@ function TestPrometheus:testGaugeIncDec()
   luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), -1)
   luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 2)
 end
+function TestPrometheus:testGaugeDel()
+  self.gauge1:inc(1)
+  luaunit.assertEquals(self.dict:get("gauge1"), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge1:del()
+  luaunit.assertEquals(self.dict:get("gauge1"), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+
+  self.gauge2:inc(1, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge2:del({"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+end
+function TestPrometheus:testReset()
+  self.gauge1:inc(1)
+  luaunit.assertEquals(self.dict:get("gauge1"), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge1:reset()
+  luaunit.assertEquals(self.dict:get("gauge1"), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge1:inc(3)
+  luaunit.assertEquals(self.dict:get("gauge1"), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge2:inc(1, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge2:inc(4, {"f2value", "f1value2"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value2"}'), 4)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.gauge2:reset()
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), nil)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value2"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+  luaunit.assertEquals(self.dict:get("gauge1"), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.counter1:inc()
+  self.counter1:inc(4)
+  self.counter2:inc(1, {"v2", "v1"})
+  self.counter2:inc(3, {"v2", "v2"})
+
+  luaunit.assertEquals(self.dict:get("metric1"), 5)
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="v1"}'), 1)
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="v2"}'), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.counter1:reset()
+  luaunit.assertEquals(self.dict:get("metric1"), nil)
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="v1"}'), 1)
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="v2"}'), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.counter1:inc(4)
+  self.counter2:reset()
+  luaunit.assertEquals(self.dict:get("metric1"), 4)
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="v1"}'), nil)
+  luaunit.assertEquals(self.dict:get('metric2{f2="v2",f1="v2"}'), nil)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), nil)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value2"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+  luaunit.assertEquals(self.dict:get("gauge1"), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+end
 function TestPrometheus:testLatencyHistogram()
   self.hist1:observe(0.35)
   self.hist1:observe(0.4)

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -236,14 +236,38 @@ function TestPrometheus:testGaugeDel()
   luaunit.assertEquals(self.dict:get("gauge1"), nil)
   luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
 
-
   self.gauge2:inc(1, {"f2value", "f1value"})
   luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 1)
   luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
 
+  self.gauge2:del({"f2value"})
+  luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+
   self.gauge2:del({"f2value", "f1value"})
   luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+end
+function TestPrometheus:testCounterDel()
+  self.counter1:inc(1)
+  luaunit.assertEquals(self.dict:get("metric1"), 1)
   luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.counter1:del()
+  luaunit.assertEquals(self.dict:get("metric1"), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.counter2:inc(1, {"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('metric2{f2="f2value",f1="f1value"}'), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  self.counter2:del()
+  luaunit.assertEquals(self.dict:get('metric2{f2="f2value",f1="f1value"}'), 1)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
+
+  self.counter2:del({"f2value", "f1value"})
+  luaunit.assertEquals(self.dict:get('metric2{f2="f2value",f1="f1value"}'), nil)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 1)
 end
 function TestPrometheus:testReset()
   self.gauge1:inc(1)


### PR DESCRIPTION
Recently we  use nginx-lua to finish some health-check jobs towards k8s endpoints for services and we collect the health-check results to prometheus.  We use a metric named `health_check_result` with label named `endpoint`, and the label values are the endpoints addresses. 

The problem is that:
As we know, k8s endpoints often change where we do the scaling for services, which cause the `endpoint`  label inflating. This may causes some kind of "memory leak", more over, we don't need to observe such nonexistent endpoints any more.
So we have to accordingly delete the endpoints from this metric which are already destroyed in k8s. 

I implemented the `del()` and `reset()` functions for both counter and gauge, and the usages are  consistent with `prometheus/client_golang`.  I think they might be useful for us.
