### PR TITLE
Follow-up adjustments to the recent performance improvement changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,4 +40,4 @@ script:
   - lua -lluacov prometheus_test.lua
 
 after_success:
-  - luacov-coveralls --include %./prometheus.lua
+  - luacov-coveralls --include %./prometheus.lua --include %./prometheus_resty_counter.lua

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ to the beginning of `nginx.conf` to ensure the modules are loaded.
 
 ### init()
 
-**syntax:** require("prometheus").init(*dict_name*, [*prefix*, *sync_interval*])
+**syntax:** require("prometheus").init(*dict_name*, [*prefix*])
 
 Initializes the module. This should be called once from the
 [init_by_lua](https://github.com/openresty/lua-nginx-module#init_by_lua)
@@ -103,10 +103,6 @@ section in nginx configuration.
   store all metrics. Defaults to `prometheus_metrics` if not specified.
 * `prefix` is an optional string which will be prepended to metric names on
   output.
-* `sync_interval` is an optional number that sets `lua-resty-counter` sync
-  interval in seconds. This sets the boundary on eventual consistency of
-  counter metrics. Defaults to 1.
-
 
 Returns a `prometheus` object that should be used to register metrics.
 
@@ -119,10 +115,14 @@ init_by_lua '
 
 ### init_worker()
 
-**syntax:** prometheus:init_worker()
+**syntax:** prometheus:init_worker([*sync_interval*])
 
-Initialize per-worker counters. This must be called from the
+Initializes per-worker counter. This must be called from the
 `init_worker_by_lua` section of nginx configuration.
+
+* `sync_interval` is an optional number that sets `lua-resty-counter` sync
+  interval in seconds. This sets the boundary on eventual consistency of
+  counter metrics. Defaults to 1.
 
 Example:
 ```

--- a/README.md
+++ b/README.md
@@ -433,9 +433,14 @@ server {
 
 ## Credits
 
-- Created and maintained by Anton Tolchanov (@knyar)
-- Metrix prefix support contributed by david birdsong (@davidbirdsong)
-- Gauge support contributed by Cosmo Petrich (@cosmopetrich)
+- Created and maintained by Anton Tolchanov ([@knyar](https://github.com/knyar))
+- Metrix prefix support contributed by david birdsong ([@davidbirdsong](
+  https://github.com/davidbirdsong))
+- Gauge support contributed by Cosmo Petrich ([@cosmopetrich](
+  https://github.com/cosmopetrich))
+- Performance improvements and per-worker counters are contributed by Wangchong
+  Zhou ([@fffonion](https://github.com/fffonion)) / [@Kong](
+  https://github.com/Kong).
 
 ## License
 

--- a/prometheus.lua
+++ b/prometheus.lua
@@ -39,7 +39,7 @@
 -- https://github.com/knyar/nginx-lua-prometheus
 -- Released under MIT license.
 
-local resty_counter_lib = require("prometheus.resty_counter")
+local resty_counter_lib = require("prometheus_resty_counter")
 
 local Prometheus = {}
 local mt = { __index = Prometheus }

--- a/prometheus.lua
+++ b/prometheus.lua
@@ -462,11 +462,10 @@ end
 --     used to store all metrics
 --   prefix: (optional string) if supplied, prefix is added to all
 --     metric names on output
---   sync_interval: per-worker counter sync interval (in seconds).
 --
 -- Returns:
 --   an object that should be used to register metrics.
-function Prometheus.init(dict_name, prefix, sync_interval)
+function Prometheus.init(dict_name, prefix)
   local self = setmetatable({}, mt)
   dict_name = dict_name or "prometheus_metrics"
   self.dict_name = dict_name
@@ -488,8 +487,6 @@ function Prometheus.init(dict_name, prefix, sync_interval)
 
   self:counter(ERROR_METRIC_NAME, "Number of nginx-lua-prometheus errors")
   self.dict:set(ERROR_METRIC_NAME, 0)
-
-  self.sync_interval = sync_interval or 1
   return self
 end
 
@@ -497,7 +494,11 @@ end
 --
 -- This should be called once from the `init_worker_by_lua` section in nginx
 -- configuration.
-function Prometheus:init_worker()
+--
+-- Args:
+--   sync_interval: per-worker counter sync interval (in seconds).
+function Prometheus:init_worker(sync_interval)
+  self.sync_interval = sync_interval or 1
   local counter_instance, err = resty_counter_lib.new(
       self.dict_name, self.sync_interval)
   if err then

--- a/prometheus.lua
+++ b/prometheus.lua
@@ -560,7 +560,7 @@ end
 
 function Prometheus:log_error(...)
   ngx.log(ngx.ERR, ...)
-  self._counter:incr(ERROR_METRIC_NAME, 1, 0)
+  self.dict:incr(ERROR_METRIC_NAME, 1, 0)
 end
 
 function Prometheus:log_error_kv(key, value, err)

--- a/prometheus_resty_counter.lua
+++ b/prometheus_resty_counter.lua
@@ -1,13 +1,26 @@
---[[
-    Lock-free counter for OpenResty
-    Taken from https://github.com/Kong/lua-resty-counter
-    Vendored version is v0.2.0
-    Licensed under Apache 2.0
-]]--
 local ngx_shared = ngx.shared
+local pairs = pairs
+local ngx = ngx
+local error = error
+local setmetatable = setmetatable
+local tonumber = tonumber
 
+local clear_tab
+do
+  local ok
+  ok, clear_tab = pcall(require, "table.clear")
+  if not ok then
+    clear_tab = function(tab)
+      for k in pairs(tab) do
+        tab[k] = nil
+      end
+    end
+  end
+end
 
-local _M = {}
+local _M = {
+  _VERSION = '0.2.1'
+}
 local mt = { __index = _M }
 
 -- local cache of counters increments
@@ -21,13 +34,14 @@ local function sync(_, self)
   local err, _
   local ok = true
   for k, v in pairs(self.increments) do
-    self.increments[k] = nil
     _, err, _ = self.dict:incr(k, v, 0)
     if err then
       ngx.log(ngx.WARN, "error increasing counter in shdict key: ", k, ", err: ", err)
       ok = false
     end
   end
+
+  clear_tab(self.increments)
   return ok
 end
 

--- a/prometheus_resty_counter.update.sh
+++ b/prometheus_resty_counter.update.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+# This script updates the lua-resty-counter [1] included with this library
+# for convenience.
+# [1] https://github.com/Kong/lua-resty-counter
+
+set -exu
+URL='https://raw.githubusercontent.com/Kong/lua-resty-counter/master/lib/resty/counter.lua'
+curl -s ${URL} > prometheus_resty_counter.lua


### PR DESCRIPTION
- Rename vendored resty_counter library to make it easier to use without Resty.
- Make tests actually use resty_counter.
- Make `inc()` on a gauge skip counters to maintain strong consistency.
- Move `sync_interval` to `init_worker`.
- Add more details to README and code comments.

@fffonion, since this involves your improvements, may I ask you to take a quick look at this please before I merge it? Please let me know if you would prefer to be mentioned in the `README.md` in a different way,  or not mentioned at all. Thanks!
