### PR TITLE
Luarocks: Add a source tag to spec.

### DIFF
--- a/nginx-lua-prometheus-0.20200420-1.rockspec
+++ b/nginx-lua-prometheus-0.20200420-1.rockspec
@@ -4,7 +4,8 @@ package = "nginx-lua-prometheus"
 version = "0.20200420-1"
 
 source = {
-  url = "git://github.com/knyar/nginx-lua-prometheus.git"
+  url = "git://github.com/knyar/nginx-lua-prometheus.git",
+  tag = "0.20200420"
 }
 
 description = {


### PR DESCRIPTION
Nowadays all luarocks versions are pointed to master and not to the real
tag. With this change, each version is pointed to the right git version.

This is causing problems with old versions, where some breaking changes
has been made on the 0.20200420 version.
Also, if you can check the following file: 

https://luarocks.org/manifests/knyar/nginx-lua-prometheus-0.20181120-2.rockspec

And change the following lines: 
```
source = {
  url = "git://github.com/knyar/nginx-lua-prometheus.git",
  tag = "0.20181120"
}
```
And it's builds correctly: 
```

$ cat nginx-lua-prometheus-0.20181120-2.rockspec
-- Note, this file must have version in its name
-- (see https://github.com/knyar/nginx-lua-prometheus/issues/27)
package = "nginx-lua-prometheus"
version = "0.20181120-2"

source = {
  url = "git://github.com/knyar/nginx-lua-prometheus.git",
  tag = "0.20181120"
}

description = {
  summary = "Prometheus metric library for Nginx",
  homepage = "https://github.com/knyar/nginx-lua-prometheus",
  license = "MIT"
}

dependencies = {
  "lua >= 5.1",
}

build = {
    type = "builtin",
    modules = {
        ["nginx.prometheus"] = "prometheus.lua"
    }
}
$ luarocks pack nginx-lua-prometheus-0.20181120-2.rockspec
Cloning into 'nginx-lua-prometheus'...
remote: Enumerating objects: 9, done.
remote: Counting objects: 100% (9/9), done.
remote: Compressing objects: 100% (8/8), done.
remote: Total 9 (delta 0), reused 3 (delta 0), pack-reused 0
Receiving objects: 100% (9/9), 12.18 KiB | 12.18 MiB/s, done.
Note: switching to '379c0a4d4d6f3c5b0eb93691fc7e14fff498e1ca'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

Packed: /tmp/nginx-lua-prometheus-0.20181120-2.src.rock
$
```


Signed-off-by: Eloy Coto <eloy.coto@acalustra.com>