### PR TITLE
Small improvements in integration tests script

### DIFF
--- a/integration/test.sh
+++ b/integration/test.sh
@@ -6,7 +6,9 @@ base_dir="$(cd "$(dirname "$0")"; pwd -P)"
 container_name="nginx_lua_prometheus_integration_test_nginx"
 image_name="${container_name}_image"
 
-docker build -t ${image_name} ${base_dir}
+cd "${base_dir}"
+
+docker build -t ${image_name} .
 
 function cleanup {
   docker rm -f ${container_name} || true
@@ -15,7 +17,13 @@ cleanup
 trap cleanup EXIT
 
 docker run -d --name ${container_name} -p 18001:18001 -p 18002:18002 \
-  -v ${base_dir}/../:/nginx-lua-prometheus ${image_name} \
+  -v "${base_dir}/../:/nginx-lua-prometheus" ${image_name} \
   nginx -c /nginx-lua-prometheus/integration/nginx.conf
 
 go run test.go
+
+if docker logs ${container_name} 2>&1 | grep -q 'error'; then
+  echo "There were unexpected errors in the log:"
+  docker logs ${container_name}
+  exit 1
+fi


### PR DESCRIPTION
This PR contains few improvements to integration tests, that came in handy while I was working with this repository in past few days:
- allow the script to be run from any directory
- quote `${base_dir}`, just in case someone runs the script from directory containing whitesapce (and it makes my linter happy)
- after successful run, check also the logs for unexpected errors, fail the tests if there were any (it happened to me that the log was full of errors, but the test passed)
