### PR TITLE
Configurable name for error metric

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ so they get set immediately before metrics are returned to the client.
 
 ### init()
 
-**syntax:** require("prometheus").init(*dict_name*, [*prefix*])
+**syntax:** require("prometheus").init(*dict_name*, [*prefix*, [*error_metric_name*]])
 
 Initializes the module. This should be called once from the
 [init_by_lua](https://github.com/openresty/lua-nginx-module#init_by_lua)
@@ -93,6 +93,9 @@ section in nginx configuration.
   store all metrics. Defaults to `prometheus_metrics` if not specified.
 * `prefix` is an optional string which will be prepended to metric names on
   output.
+* `error_metric_name` is an optional string that can be used to change
+  the default name of error metric (see [Built-in metrics](#built-in-metrics)
+  for details).
 
 Returns a `prometheus` object that should be used to register metrics.
 
@@ -299,11 +302,11 @@ just before `prometheus::collect()` to return a real-time value.
 
 **syntax:** gauge:inc(*value*, *label_values*)
 
-Increments or decrements a previously registered gauge. This is usually called 
-when you want to observe the real-time value of a metric that can both be 
+Increments or decrements a previously registered gauge. This is usually called
+when you want to observe the real-time value of a metric that can both be
 increased and decreased.
 
-* `value` is a value that should be added to the gauge. It could be a negative 
+* `value` is a value that should be added to the gauge. It could be a negative
 value when you need to decrease the value of the gauge. Defaults to 1.
 * `label_values` is an array of label values.
 
@@ -316,10 +319,10 @@ stripped from label values.
 
 **syntax:** gauge:del(*label_values*)
 
-Delete a previously registered gauge. This is usually called when you don't 
-need to observe such gauge (or a metric with specific label values in this 
-gauge) any more. If this gauge has labels, you have to pass `label_values` 
-to delete the specific metric of this gauge. If you want to delete all the 
+Delete a previously registered gauge. This is usually called when you don't
+need to observe such gauge (or a metric with specific label values in this
+gauge) any more. If this gauge has labels, you have to pass `label_values`
+to delete the specific metric of this gauge. If you want to delete all the
 metrics of a gauge with labels, you should call `Gauge:reset()`.
 
 * `label_values` is an array of label values.
@@ -333,8 +336,8 @@ stripped from label values.
 
 **syntax:** gauge:reset()
 
-Delete all metrics for a previously registered gauge. If this gauge have no 
-labels, it is just the same as `Gauge:del()` function. If this gauge have labels, 
+Delete all metrics for a previously registered gauge. If this gauge have no
+labels, it is just the same as `Gauge:del()` function. If this gauge have labels,
 it will delete all the metrics with different label values.
 
 ### histogram:observe()
@@ -358,7 +361,8 @@ log_by_lua '
 
 ### Built-in metrics
 
-The module increments the `nginx_metric_errors_total` metric if it encounters
+The module increments an error metric called `nginx_metric_errors_total`
+(unless another name was configured in [init()](#init)) if it encounters
 an error (for example, when `lua_shared_dict` becomes full). You might want
 to configure an alert on that metric.
 

--- a/prometheus.lua
+++ b/prometheus.lua
@@ -63,8 +63,8 @@ local TYPE_LITERAL = {
   [TYPE_HISTOGRAM] = "histogram",
 }
 
--- Error metric incremented for this library.
-local ERROR_METRIC_NAME = "nginx_metric_errors_total"
+-- Default name for error metric incremented by this library.
+local DEFAULT_ERROR_METRIC_NAME = "nginx_metric_errors_total"
 
 -- Prefix for internal shared dictionary items.
 local KEY_INDEX_PREFIX = "__ngx_prom__"
@@ -486,7 +486,7 @@ end
 --
 -- Returns:
 --   an object that should be used to register metrics.
-function Prometheus.init(dict_name, prefix)
+function Prometheus.init(dict_name, prefix, error_metric_name)
   local self = setmetatable({}, mt)
   dict_name = dict_name or "prometheus_metrics"
   self.dict_name = dict_name
@@ -496,20 +496,17 @@ function Prometheus.init(dict_name, prefix)
       "Please define the dictionary using `lua_shared_dict`.", 2)
   end
 
-  if prefix then
-    self.prefix = prefix
-  else
-    self.prefix = ''
-  end
+  self.prefix = prefix or ''
+  self.error_metric_name = error_metric_name or DEFAULT_ERROR_METRIC_NAME
 
   self.registry = {}
   self.key_index = key_index_lib.new(self.dict, KEY_INDEX_PREFIX)
 
   self.initialized = true
 
-  self:counter(ERROR_METRIC_NAME, "Number of nginx-lua-prometheus errors")
-  self.dict:set(ERROR_METRIC_NAME, 0)
-  local err = self.key_index:add(ERROR_METRIC_NAME)
+  self:counter(self.error_metric_name, "Number of nginx-lua-prometheus errors")
+  self.dict:set(self.error_metric_name, 0)
+  local err = self.key_index:add(self.error_metric_name)
   if err then
     self:log_error(err)
   end
@@ -698,7 +695,7 @@ end
 -- Log an error, incrementing the error counter.
 function Prometheus:log_error(...)
   ngx.log(ngx.ERR, ...)
-  self.dict:incr(ERROR_METRIC_NAME, 1, 0)
+  self.dict:incr(self.error_metric_name, 1, 0)
 end
 
 -- Log an error that happened while setting up a dictionary key.


### PR DESCRIPTION
Hi,

Here is one last little improvement from me... We have some company-wide rules, which specify how some common metrics should be named. It greatly simplifies creation of generic alerts and Grafana boards, amongst other things. Unfortunately, the name of the error metric should be just `errors_total`, so until now we had to patch the prometheus.lua to satisfy our rules.

This PR is meant to make the error metric name configurable, so we can use vanilla version of this library.