### PR TITLE
Simplify library initialization instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ of `nginx.conf`:
 ```
 lua_shared_dict prometheus_metrics 10M;
 lua_package_path "/path/to/nginx-lua-prometheus/?.lua;;";
-init_by_lua '
+init_worker_by_lua_block {
   prometheus = require("prometheus").init("prometheus_metrics")
   metric_requests = prometheus:counter(
     "nginx_http_requests_total", "Number of HTTP requests", {"host", "status"})
@@ -36,12 +36,11 @@ init_by_lua '
     "nginx_http_request_duration_seconds", "HTTP request latency", {"host"})
   metric_connections = prometheus:gauge(
     "nginx_http_connections", "Number of HTTP connections", {"state"})
-';
-init_worker_by_lua 'prometheus:init_worker()';
-log_by_lua '
+}
+log_by_lua_block {
   metric_requests:inc(1, {ngx.var.server_name, ngx.var.status})
   metric_latency:observe(tonumber(ngx.var.request_time), {ngx.var.server_name})
-';
+}
 ```
 
 This:
@@ -65,12 +64,12 @@ server {
   allow 192.168.0.0/16;
   deny all;
   location /metrics {
-    content_by_lua '
+    content_by_lua_block {
       metric_connections:set(ngx.var.connections_reading, {"reading"})
       metric_connections:set(ngx.var.connections_waiting, {"waiting"})
       metric_connections:set(ngx.var.connections_writing, {"writing"})
       prometheus:collect()
-    ';
+    }
   }
 }
 ```
@@ -86,8 +85,8 @@ so they get set immediately before metrics are returned to the client.
 **syntax:** require("prometheus").init(*dict_name*, [*prefix*, [*error_metric_name*]])
 
 Initializes the module. This should be called once from the
-[init_by_lua](https://github.com/openresty/lua-nginx-module#init_by_lua)
-section in nginx configuration.
+[init_worker_by_lua_block](https://github.com/openresty/lua-nginx-module#init_worker_by_lua_block)
+section of nginx configuration.
 
 * `dict_name` is the name of the nginx shared dictionary which will be used to
   store all metrics. Defaults to `prometheus_metrics` if not specified.
@@ -101,17 +100,22 @@ Returns a `prometheus` object that should be used to register metrics.
 
 Example:
 ```
-init_by_lua '
+init_worker_by_lua_block {
   prometheus = require("prometheus").init("prometheus_metrics")
-';
+}
 ```
 
 ### init_worker()
 
 **syntax:** prometheus:init_worker([*sync_interval*])
 
-Initializes per-worker counter. This must be called from the
-`init_worker_by_lua` section of nginx configuration.
+Initializes per-worker counter. This is typically done automatically by the
+`init` function if it's called from `init_worker_by_lua_block`. However,
+if you would like to override `sync_interval`, you can call the main `init`
+function in the [init_by_lua_block](
+https://github.com/openresty/lua-nginx-module#init_by_lua_block) section, and
+then manually call `prometheus:init_worker` in
+[init_worker_by_lua_block](https://github.com/openresty/lua-nginx-module#init_worker_by_lua_block).
 
 * `sync_interval` is an optional number that sets `lua-resty-counter` sync
   interval in seconds. This sets the boundary on eventual consistency of
@@ -119,16 +123,23 @@ Initializes per-worker counter. This must be called from the
 
 Example:
 ```
-init_worker_by_lua 'prometheus:init_worker()';
+init_by_lua_block {
+  prometheus = require("prometheus").init("prometheus_metrics")
+  -- metrics defined here
+}
+init_worker_by_lua_block { prometheus:init_worker() }
 ```
 
 ### prometheus:counter()
 
 **syntax:** prometheus:counter(*name*, *description*, *label_names*)
 
-Registers a counter. Should be called once from the
-[init_by_lua](https://github.com/openresty/lua-nginx-module#init_by_lua)
-section.
+Registers a counter. Should be called once for each counter from the
+[init_worker_by_lua_block](
+https://github.com/openresty/lua-nginx-module#init_worker_by_lua_block)
+section (or [init_by_lua_block](
+https://github.com/openresty/lua-nginx-module#init_by_lua_block)
+if that's where you are initializing the library).
 
 * `name` is the name of the metric.
 * `description` is the text description that will be presented to Prometheus
@@ -143,21 +154,22 @@ Returns a `counter` object that can later be incremented.
 
 Example:
 ```
-init_by_lua '
+init_worker_by_lua_block {
   prometheus = require("prometheus").init("prometheus_metrics")
   metric_bytes = prometheus:counter(
     "nginx_http_request_size_bytes", "Total size of incoming requests")
   metric_requests = prometheus:counter(
     "nginx_http_requests_total", "Number of HTTP requests", {"host", "status"})
-';
+}
 ```
 
 ### prometheus:gauge()
 
 **syntax:** prometheus:gauge(*name*, *description*, *label_names*)
 
-Registers a gauge. Should be called once from the
-[init_by_lua](https://github.com/openresty/lua-nginx-module#init_by_lua)
+Registers a gauge. Should be called once for each gauge from the
+[init_worker_by_lua_block](
+https://github.com/openresty/lua-nginx-module#init_worker_by_lua_block)
 section.
 
 * `name` is the name of the metric.
@@ -170,11 +182,11 @@ Returns a `gauge` object that can later be set.
 
 Example:
 ```
-init_by_lua '
+init_worker_by_lua_block {
   prometheus = require("prometheus").init("prometheus_metrics")
   metric_connections = prometheus:gauge(
     "nginx_http_connections", "Number of HTTP connections", {"state"})
-';
+}
 ```
 
 ### prometheus:histogram()
@@ -182,8 +194,9 @@ init_by_lua '
 **syntax:** prometheus:histogram(*name*, *description*, *label_names*,
   *buckets*)
 
-Registers a histogram. Should be called once from the
-[init_by_lua](https://github.com/openresty/lua-nginx-module#init_by_lua)
+Registers a histogram. Should be called once for each histogram from the
+[init_worker_by_lua_block](
+https://github.com/openresty/lua-nginx-module#init_worker_by_lua_block)
 section.
 
 * `name` is the name of the metric.
@@ -196,14 +209,14 @@ Returns a `histogram` object that can later be used to record samples.
 
 Example:
 ```
-init_by_lua '
+init_worker_by_lua_block {
   prometheus = require("prometheus").init("prometheus_metrics")
   metric_latency = prometheus:histogram(
     "nginx_http_request_duration_seconds", "HTTP request latency", {"host"})
   metric_response_sizes = prometheus:histogram(
     "nginx_http_response_size_bytes", "Size of HTTP responses", nil,
     {10,100,1000,10000,100000,1000000})
-';
+}
 ```
 
 ### prometheus:collect()
@@ -212,13 +225,13 @@ init_by_lua '
 
 Presents all metrics in a text format compatible with Prometheus. This should be
 called in
-[content_by_lua](https://github.com/openresty/lua-nginx-module#content_by_lua)
+[content_by_lua_block](https://github.com/openresty/lua-nginx-module#content_by_lua_block)
 to expose the metrics on a separate HTTP page.
 
 Example:
 ```
 location /metrics {
-  content_by_lua 'prometheus:collect()';
+  content_by_lua_block { prometheus:collect() }
   allow 192.168.0.0/16;
   deny all;
 }
@@ -235,7 +248,7 @@ Returns metric data as an array of strings.
 **syntax:** counter:inc(*value*, *label_values*)
 
 Increments a previously registered counter. This is usually called from
-[log_by_lua](https://github.com/openresty/lua-nginx-module#log_by_lua)
+[log_by_lua_block](https://github.com/openresty/lua-nginx-module#log_by_lua_block)
 globally or per server/location.
 
 * `value` is a value that should be added to the counter. Defaults to 1.
@@ -248,10 +261,10 @@ stripped from label values.
 
 Example:
 ```
-log_by_lua '
+log_by_lua_block {
   metric_bytes:inc(tonumber(ngx.var.request_length))
   metric_requests:inc(1, {ngx.var.server_name, ngx.var.status})
-';
+}
 ```
 
 ### counter:del()
@@ -290,9 +303,9 @@ allow all workers to sync their counters.
 **syntax:** gauge:set(*value*, *label_values*)
 
 Sets the current value of a previously registered gauge. This could be called
-from [log_by_lua](https://github.com/openresty/lua-nginx-module#log_by_lua)
+from [log_by_lua_block](https://github.com/openresty/lua-nginx-module#log_by_lua_block)
 globally or per server/location to modify a gauge on each request, or from
-[content_by_lua](https://github.com/openresty/lua-nginx-module#content_by_lua)
+[content_by_lua_block](https://github.com/openresty/lua-nginx-module#content_by_lua_block)
 just before `prometheus::collect()` to return a real-time value.
 
 * `value` is a value that the gauge should be set to. Required.
@@ -345,7 +358,7 @@ it will delete all the metrics with different label values.
 **syntax:** histogram:observe(*value*, *label_values*)
 
 Records a value in a previously registered histogram. Usually called from
-[log_by_lua](https://github.com/openresty/lua-nginx-module#log_by_lua)
+[log_by_lua_block](https://github.com/openresty/lua-nginx-module#log_by_lua_block)
 globally or per server/location.
 
 * `value` is a value that should be recorded. Required.
@@ -353,10 +366,10 @@ globally or per server/location.
 
 Example:
 ```
-log_by_lua '
+log_by_lua_block {
   metric_latency:observe(tonumber(ngx.var.request_time), {ngx.var.server_name})
   metric_response_sizes:observe(tonumber(ngx.var.bytes_sent))
-';
+}
 ```
 
 ### Built-in metrics
@@ -378,7 +391,7 @@ example.
 ```
 server {
   listen 9145;
-  content_by_lua '
+  content_by_lua_block {
     local sock = assert(ngx.req.socket(true))
     local data = sock:receive()
     local location = "GET /metrics"
@@ -390,8 +403,8 @@ server {
     else
       ngx.say("HTTP/1.1 404 Not Found")
     end
-  ';
   }
+}
 ```
 
 ## Troubleshooting

--- a/integration/nginx.conf
+++ b/integration/nginx.conf
@@ -14,8 +14,9 @@ http {
 
     error_log stderr;
 
-    init_by_lua_block {
-        prometheus = require("prometheus").init("prometheus_metrics")
+    init_worker_by_lua_block {
+        prometheus = require("prometheus").init("prometheus_metrics",
+	  {sync_interval=0.4})
         metric_requests = prometheus:counter("requests_total",
           "Number of HTTP requests", {"host", "status"})
         metric_latency = prometheus:histogram("request_duration_seconds",
@@ -25,7 +26,6 @@ http {
         metric_connections = prometheus:gauge("connections",
           "Number of HTTP connections", {"state"})
     }
-    init_worker_by_lua_block { prometheus:init_worker(0.4) }
     log_by_lua_block {
         metric_requests:inc(1, {ngx.var.server_name, ngx.var.status})
         metric_latency:observe(tonumber(ngx.var.request_time),

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -85,7 +85,6 @@ function TestPrometheus:setUp()
   self.dict = setmetatable({}, SimpleDict)
   ngx.shared.metrics = self.dict
   self.p = require('prometheus').init('metrics')
-  self.p:init_worker()
   self.counter1 = self.p:counter("metric1", "Metric 1")
   self.counter2 = self.p:counter("metric2", "Metric 2", {"f2", "f1"})
   self.counter3 = self.p:counter("metric3", "Metric 3", {"f3"})
@@ -99,6 +98,33 @@ function TestPrometheus.tearDown()
 end
 function TestPrometheus:testInit()
   luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+  luaunit.assertEquals(ngx.logs, nil)
+end
+function TestPrometheus:testInitOptions()
+  self.dict = setmetatable({}, SimpleDict)
+  ngx.shared.metrics = self.dict
+
+  local p1 = require('prometheus').init("metrics")
+  assert(p1.prefix == "")
+  assert(p1.sync_interval == 1)
+  assert(p1.error_metric_name == "nginx_metric_errors_total")
+
+  local p2 = require('prometheus').init("metrics", "test_pref_")
+  assert(p2.prefix == "test_pref_")
+  assert(p2.sync_interval == 1)
+  assert(p2.error_metric_name == "nginx_metric_errors_total")
+
+  local p3 = require('prometheus').init("metrics", {sync_interval=3})
+  assert(p3.prefix == "")
+  assert(p3.sync_interval == 3)
+  assert(p3.error_metric_name == "nginx_metric_errors_total")
+
+  local p4 = require('prometheus').init("metrics", {
+    prefix="foo", sync_interval=3, error_metric_name="foobar"})
+  assert(p4.prefix == "foo")
+  assert(p4.sync_interval == 3)
+  assert(p4.error_metric_name == "foobar")
+
   luaunit.assertEquals(ngx.logs, nil)
 end
 function TestPrometheus.testErrorUnitialized()
@@ -510,7 +536,6 @@ function TestPrometheus:testCollectWithPrefix()
   self.dict = setmetatable({}, SimpleDict)
   ngx.shared.metrics = self.dict
   local p = require('prometheus').init("metrics", "test_pref_")
-  p:init_worker()
 
   local counter1 = p:counter("metric1", "Metric 1")
   local gauge1 = p:gauge("gauge1", "Gauge 1")

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -65,6 +65,9 @@ end
 function Nginx.sleep() end
 Nginx.timer = {}
 function Nginx.timer.every(_, _, _) end
+function Nginx.get_phase()
+  return 'init_worker'
+end
 
 ngx = setmetatable({shared={}}, Nginx)
 

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -127,6 +127,16 @@ function TestPrometheus:testInitOptions()
 
   luaunit.assertEquals(ngx.logs, nil)
 end
+function TestPrometheus:testInitWorker()
+  self.dict = setmetatable({}, SimpleDict)
+  ngx.shared.metrics = self.dict
+
+  local p1 = require('prometheus').init("metrics")
+  p1:init_worker(3)
+
+  luaunit.assertEquals(#ngx.logs, 1)
+  luaunit.assertStrContains(ngx.logs[1], "do not explicitly call init_worker")
+end
 function TestPrometheus.testErrorUnitialized()
   local p = require('prometheus')
   p:counter("metric1")


### PR DESCRIPTION
- add more details to the error message about counter initalization.
- make `init` call `init_worker` automatically if `init` is called from the `init_worker` nginx section.
- deprecate explicitly calling `init_worker`
- use `_block` versions of all lua sections in the README.

This should fix #92. @dolik-rce, since you raised that issue, would you mind reviewing this?