### PR TITLE
Fix getting key error when key not found

### DIFF
--- a/prometheus.lua
+++ b/prometheus.lua
@@ -470,7 +470,9 @@ local function reset(self)
         end
       end
     else
-      self._log_error("Error getting '", key, "': ", key_err)
+      if type(key_err) == "string" then
+        self._log_error("Error getting '", key, "': ", key_err)
+      end
     end
   end
 

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -29,12 +29,16 @@ function SimpleDict:incr(k, v, init)
   return self.dict[k], nil  -- newval, err
 end
 function SimpleDict:get(k)
+  -- simulate key not exist
+  if k == "gauge2{f2=\"key_not_exist\",f1=\"key_not_exist\"}" then
+    return nil, nil
+  end
   -- simulate an error
   if k == "gauge2{f2=\"dict_error\",f1=\"dict_error\"}" then
-    return nil, 0
+    return nil, "dict error"
   end
   if not self.dict then self.dict = {} end
-  return self.dict[k], 0  -- value, flags
+  return self.dict[k], nil  -- value, err
 end
 function SimpleDict:delete(k)
   self.dict[k] = nil
@@ -409,6 +413,13 @@ function TestPrometheus:testReset()
   luaunit.assertEquals(self.dict:get('gauge2{f2="f2value",f1="f1value2"}'), nil)
   luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
   luaunit.assertEquals(self.dict:get("gauge1"), 3)
+  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
+
+  -- key not exist
+  self.gauge2:inc(4, {"key_not_exist", "key_not_exist"})
+  self.gauge2:reset()
+  self.p.key_index:sync()
+  luaunit.assertEquals(self.dict:get('gauge2{f2="key_not_exist",f1="key_not_exist"}'), nil)
   luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
 
   -- error get from dict


### PR DESCRIPTION
Fix getting key error when key not found.

When I registers a counter and a histogram like this:

```
init_worker_by_lua_block {
  prometheus = require("prometheus").init("prometheus_metrics")
  metric_requests = prometheus:counter(
    "nginx_http_requests", "Number of HTTP requests", nil)
  metric_response_sizes = prometheus:histogram(
    "nginx_http_response_size_bytes", "Size of HTTP responses", nil,
    {10,100,1000,10000,100000,1000000})
}
```

`metric_response_sizes` covering a range from 10 byte to 1000000 byte as bucket boundaries, function `lookup_or_create` will added all the buckets to `self._key_index` when `metric_response_sizes:observe` be called at first time, if there is no one response size less than 10 byte, the related key was not created in `self._dict`. Then we call `metric_requests:reset` this kind of error log will appears.

```lua
  for _, key in ipairs(keys) do
    local value, key_err = self._dict:get(key)
    if value then
      -- without labels equal, or with labels and the part before { equals
      if key == self.name or name_prefix == string.sub(key, 1, name_prefix_length) then -- this check is after self._dict:get
        self._key_index:remove(key)
        local _, err = self._dict:safe_set(key, nil)
        if err then
          self._log_error("Error resetting '", key, "': ", err)
        end
      end
    else
      self._log_error("Error getting '", key, "': ", key_err) -- key_err may be nil when can not found key in self._dict
    end
  end
```