### PR TITLE
Feature/allow utf8 lable value

### DIFF
--- a/prometheus.lua
+++ b/prometheus.lua
@@ -93,24 +93,22 @@ local accept_range = {
 --   (bool) whether the input string is a valid utf8 string.
 local function validate_utf8_string(str)
   local i, n = 1, #str
-  local first, second, third, fourth, size, range_idx
+  local first, byte, left_size, range_idx
   while i <= n do
     first = string.byte(str, i)
-    if first < 0x80 then -- ascii
-      i = i + 1
-    else
+    if first >= 0x80 then
       range_idx = 1
       if first >= 0xC2 and first <= 0xDF then --2 bytes
-        size = 2
+        left_size = 1
       elseif first >= 0xE0 and first <= 0xEF then --3 bytes
-        size = 3
+        left_size = 2
         if first == 0xE0 then
           range_idx = 2
         elseif first == 0xED then
           range_idx = 3
         end
       elseif first >= 0xF0 and first <= 0xF4 then --4 bytes
-        size = 4
+        left_size = 3
         if first == 0xF0 then
           range_idx = 4
         elseif first == 0xF4 then
@@ -120,23 +118,20 @@ local function validate_utf8_string(str)
         return false
       end
 
-      if i + size > n + 1 then
+      if i + left_size  > n then
         return false
       end
 
-      second, third, fourth  = string.byte(str, i + 1, i + size - 1)
-      if second < accept_range[range_idx].lo or second > accept_range[range_idx].hi then
-        return false
-      elseif size == 2 then
-      elseif third < accept_range[1].lo or third > accept_range[1].hi then
-        return false
-      elseif size == 3 then
-      elseif fourth < accept_range[1].lo or fourth > accept_range[1].hi then
-        return false
+      for j = 1, left_size do
+        byte = string.byte(str, i + j, i + j)
+        if byte < accept_range[range_idx].lo or byte > accept_range[range_idx].hi then
+          return false
+        end
+        range_idx = 1
       end
-
-      i = i + size
+      i = i + left_size
     end
+    i = i + 1
   end
   return true
 end

--- a/prometheus.lua
+++ b/prometheus.lua
@@ -85,7 +85,13 @@ local accept_range = {
   {lo = 0x80, hi = 0x8F}
 }
 
-local function valid_utf8_string(str)
+-- Validate utf8 string for label values.
+--
+-- Args:
+--   str: string
+-- Returns:
+--   (bool) whether the input string is a valid utf8 string.
+local function validate_utf8_string(str)
   local i, n = 1, #str
   local first, second, third, fourth, size, range_idx
   while i <= n do
@@ -150,7 +156,7 @@ local function full_metric_name(name, label_names, label_values)
   local label_parts = {}
   for idx, key in ipairs(label_names) do
     local label_value = ""
-    if type(label_values[idx]) == "string" and valid_utf8_string(label_values[idx]) then
+    if type(label_values[idx]) == "string" and validate_utf8_string(label_values[idx]) then
       label_value = label_values[idx]:gsub("\\", "\\\\"):gsub('"', '\\"')
     elseif type(label_values[idx]) ~= 'string' then
       label_value = tostring(label_values[idx])

--- a/prometheus.lua
+++ b/prometheus.lua
@@ -123,7 +123,7 @@ local function validate_utf8_string(str)
       end
 
       for j = 1, left_size do
-        byte = string.byte(str, i + j, i + j)
+        byte = string.byte(str, i + j)
         if byte < accept_range[range_idx].lo or byte > accept_range[range_idx].hi then
           return false
         end

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -255,8 +255,14 @@ function TestPrometheus:testNonPrintableLabelValues()
 end
 function TestPrometheus:testUTF8LableValues()
   self.counter2:inc(1, {"¢€𤭢", "Pay in €. Thanks."})
+  self.gauge2:set(1, {"\224\143\175", "\237\129\128"})
+  self.hist2:observe(1, {"\244\143\143\143", "\244"})
+
   self.p._counter:sync()
   luaunit.assertEquals(self.dict:get('metric2{f2="¢€𤭢",f1="Pay in €. Thanks."}'), 1)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="",f1="\237\129\128"}'), 1)
+  luaunit.assertEquals(self.dict:get('l2_sum{var="\244\143\143\143",site=""}'), 1)
+  luaunit.assertEquals(ngx.logs, nil)
 end
 function TestPrometheus:testNoValues()
   self.counter1:inc()  -- defaults to 1

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -248,10 +248,15 @@ function TestPrometheus:testNonPrintableLabelValues()
   self.hist2:observe(1, {"\166omg", "fooшbar"})
 
   self.p._counter:sync()
-  luaunit.assertEquals(self.dict:get('metric2{f2="foo",f1="bazqux"}'), 1)
-  luaunit.assertEquals(self.dict:get('gauge2{f2="z",f1=""}'), 1)
-  luaunit.assertEquals(self.dict:get('l2_sum{var="omg",site="foobar"}'), 1)
+  luaunit.assertEquals(self.dict:get('metric2{f2="foo",f1=""}'), 1)
+  luaunit.assertEquals(self.dict:get('gauge2{f2="z\001",f1="\002"}'), 1)
+  luaunit.assertEquals(self.dict:get('l2_sum{var="",site="fooшbar"}'), 1)
   luaunit.assertEquals(ngx.logs, nil)
+end
+function TestPrometheus:testUTF8LableValues()
+  self.counter2:inc(1, {"¢€𤭢", "Pay in €. Thanks."})
+  self.p._counter:sync()
+  luaunit.assertEquals(self.dict:get('metric2{f2="¢€𤭢",f1="Pay in €. Thanks."}'), 1)
 end
 function TestPrometheus:testNoValues()
   self.counter1:inc()  -- defaults to 1

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -248,7 +248,7 @@ function TestPrometheus:testNonPrintableLabelValues()
   self.hist2:observe(1, {"\166omg", "fooшbar"})
 
   self.p._counter:sync()
-  luaunit.assertEquals(self.dict:get('metric2{f2="foo",f1=""}'), 1)
+  luaunit.assertEquals(self.dict:get('metric2{f2="foo",f1="baz"}'), 1)
   luaunit.assertEquals(self.dict:get('gauge2{f2="z\001",f1="\002"}'), 1)
   luaunit.assertEquals(self.dict:get('l2_sum{var="",site="fooшbar"}'), 1)
   luaunit.assertEquals(ngx.logs, nil)


### PR DESCRIPTION
Hello, just implemented the feature and reimplemented the utf8 validation function which have a better performance compared to [utf8_validator.lua](https://github.com/kikito/utf8_validator.lua/blob/master/utf8_validator.lua)

here is the benchmark code [benchmark.lua](https://github.com/Gerrard-YNWA/utf8_validator.lua/blob/master/benchmark.lua) and result running on my laptop:
```
➜  utf8_validator.lua (master) ✔ resty benchmark.lua
benchmark for plain ascii, string Hello word
465.99984169006
23.000001907349
benchmark for utf8 stuff, string ¢€𤭢
1187.0000362396
45.000076293945
benchmark for mixed stuff, string Pay in €. Thanks.
1144.9999809265
39.999961853027
```
close #109 

Any suggestions?