### PR TITLE
replace safe_set with set

### DIFF
--- a/prometheus.lua
+++ b/prometheus.lua
@@ -527,7 +527,7 @@ local function set(self, value, label_values)
     self._log_error(err)
     return
   end
-  _, err = self._dict:safe_set(k, value)
+  _, err = self._dict:set(k, value)
   if err then
     self._log_error_kv(k, value, err)
   end
@@ -632,7 +632,7 @@ local function reset(self)
       end
       if remove then
         self._key_index:remove(key)
-        local _, err = self._dict:safe_set(key, nil)
+        local _, err = self._dict:set(key, nil)
         if err then
           self._log_error("Error resetting '", key, "': ", err)
         end

--- a/prometheus.lua
+++ b/prometheus.lua
@@ -424,7 +424,7 @@ end
 --   value: numeric value to increment by. Can be negative.
 --   label_values: a list of label values, in the same order as label keys.
 local function inc_gauge(self, value, label_values)
-  local k, err, _
+  local k, err, _, forcible
   k, err = lookup_or_create(self, label_values)
   if err then
     self._log_error(err)
@@ -521,7 +521,7 @@ local function set(self, value, label_values)
     return
   end
 
-  local k, _, err
+  local k, _, err, forcible
   k, err = lookup_or_create(self, label_values)
   if err then
     self._log_error(err)

--- a/prometheus.lua
+++ b/prometheus.lua
@@ -431,9 +431,9 @@ local function inc_gauge(self, value, label_values)
     return
   end
 
-  _, err, _ = self._dict:incr(k, value, 0)
-  if err then
-    self._log_error_kv(k, value, err)
+  _, err, forcible = self._dict:incr(k, value, 0)
+  if err or forcible then
+    self._log_error_kv(k, value, err or "lru eviction")
   end
 end
 
@@ -527,9 +527,9 @@ local function set(self, value, label_values)
     self._log_error(err)
     return
   end
-  _, err = self._dict:set(k, value)
-  if err then
-    self._log_error_kv(k, value, err)
+  _, err, forcible = self._dict:set(k, value)
+  if err or forcible then
+    self._log_error_kv(k, value, err or "lru eviction")
   end
 end
 

--- a/prometheus_keys.lua
+++ b/prometheus_keys.lua
@@ -85,7 +85,7 @@ function KeyIndex:add(key_or_keys)
         break
       end
       N = N+1
-      local ok, err = self.dict:safe_add(self.key_prefix .. N, key)
+      local ok, err = self.dict:add(self.key_prefix .. N, key)
       if ok then
         self.dict:incr(self.key_count, 1, 0)
         self.keys[N] = key
@@ -107,7 +107,7 @@ function KeyIndex:remove(key)
   if i then
     self.index[key] = nil
     self.keys[i] = nil
-    self.dict:safe_set(self.key_prefix .. i, nil)
+    self.dict:set(self.key_prefix .. i, nil)
     -- increment delete_count to signalize other workers that they should do a full sync
     self.dict:incr(self.delete_count, 1, 0)
     self.deleted = self.deleted + 1

--- a/prometheus_keys.lua
+++ b/prometheus_keys.lua
@@ -85,7 +85,11 @@ function KeyIndex:add(key_or_keys)
         break
       end
       N = N+1
-      local ok, err = self.dict:add(self.key_prefix .. N, key)
+      local ok, err, forcible = self.dict:add(self.key_prefix .. N, key)
+      if forcible then
+          ngx.log(ngx.ERR, "key index: add key: shdict lru eviction: idx=",
+                  self.key_prefix .. N, ", key=", key)
+      end
       if ok then
         self.dict:incr(self.key_count, 1, 0)
         self.keys[N] = key

--- a/prometheus_resty_counter.lua
+++ b/prometheus_resty_counter.lua
@@ -31,7 +31,7 @@ local timer_started = {}
 local id
 
 local function sync(_, self)
-  local err, _
+  local err, _, forcible
   local ok = true
   for k, v in pairs(self.increments) do
     _, err, forcible = self.dict:incr(k, v, 0)

--- a/prometheus_resty_counter.lua
+++ b/prometheus_resty_counter.lua
@@ -34,7 +34,10 @@ local function sync(_, self)
   local err, _
   local ok = true
   for k, v in pairs(self.increments) do
-    _, err, _ = self.dict:incr(k, v, 0)
+    _, err, forcible = self.dict:incr(k, v, 0)
+    if forcible then
+      ngx.log(ngx.WARN, "increasing counter in shdict: lru eviction: key=", k)
+    end
     if err then
       ngx.log(ngx.WARN, "error increasing counter in shdict key: ", k, ", err: ", err)
       ok = false

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -15,7 +15,7 @@ function SimpleDict:safe_set(k, v)
   return true, nil  -- ok, err
 end
 function SimpleDict:add(k, v)
-  self:add(k, v)
+  self:set(k, v)
   return true, nil  -- ok, err
 end
 function SimpleDict:incr(k, v, init)


### PR DESCRIPTION
When the number of metrics increase, especially due to label value changes or add/remove labels on reload, it's likely to use up the shdict, when mostly we want to remove the old items in shdict making use of the lru cache mechanism of shdict. The old items are supposed to be ignored.

In fact, even we insist `safe_set`, the `inc` we used in other places of codes may also purge old items. So why not make them consistent?