### PR TITLE
bugfix: limit lookup table size

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
       - run: luarocks install luacov-coveralls
       - run: luarocks install luaunit
       - run: luarocks install lrexlib-pcre2
+      - run: luarocks install lua-cjson
       - run: luacheck --globals ngx -- prometheus.lua prometheus_keys.lua prometheus_resty_counter.lua
       - run: luacheck --globals luaunit rex_pcre2 ngx TestPrometheus TestKeyIndex -- prometheus_test.lua
       - run: lua -lluacov prometheus_test.lua

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,6 @@ jobs:
       - run: luarocks install luacov-coveralls
       - run: luarocks install luaunit
       - run: luarocks install lrexlib-pcre2
-      - run: luarocks install lua-cjson
       - run: luacheck --globals ngx -- prometheus.lua prometheus_keys.lua prometheus_resty_counter.lua
       - run: luacheck --globals luaunit rex_pcre2 ngx TestPrometheus TestKeyIndex -- prometheus_test.lua
       - run: lua -lluacov prometheus_test.lua

--- a/integration/nginx.conf
+++ b/integration/nginx.conf
@@ -76,11 +76,14 @@ http {
         }
         location /get_lookup_size {
             content_by_lua_block {
-                ngx.print(require("cjson").encode({
-                    metric_counter_dummy = metric_counter_dummy.lookup_size,
-                    metric_gauge_dummy = metric_gauge_dummy.lookup_size,
-                    metric_histogram_dummy = metric_histogram_dummy.lookup_size,
-                }))
+                ngx.print(string.format([[{
+                        "metric_counter_dummy": %d,
+                        "metric_gauge_dummy": %d,
+                        "metric_histogram_dummy": %d
+                    }]],
+                    metric_counter_dummy.lookup_size,
+                    metric_gauge_dummy.lookup_size,
+                    metric_histogram_dummy.lookup_size))
             }
         }
     }

--- a/integration/nginx.conf
+++ b/integration/nginx.conf
@@ -24,6 +24,10 @@ http {
           {0.08, 0.089991, 0.1, 0.2, 0.75, 1, 1.5, 3.123232001, 5, 15, 120, 350.5, 1500, 75000, 1500000})
         metric_connections = prometheus:gauge("connections",
           "Number of HTTP connections", {"state"})
+
+        metric_counter_dummy = prometheus:counter("counter_dummy", "dummy counter", {"tag"})
+        metric_histogram_dummy = prometheus:histogram("histogram_dummy", "dummy histogram", {"tag"}, {100})
+        metric_gauge_dummy = prometheus:gauge("gauge_dummy", "dummy gauge", {"tag"})
     }
     log_by_lua_block {
         metric_requests:inc(1, {ngx.var.server_name, ngx.var.status})
@@ -57,6 +61,26 @@ http {
                 -- sleep for 10-20ms.
                 ngx.sleep(0.01 + (0.01 * math.random()))
                 ngx.say("ok")
+            }
+        }
+    }
+    server {
+        listen 18003;
+        server_name dummy;
+        location /update {
+            content_by_lua_block {
+                metric_counter_dummy:inc(1, {ngx.var.arg_tag})
+                metric_gauge_dummy:inc(1, {ngx.var.arg_tag})
+                metric_histogram_dummy:observe(1, {ngx.var.arg_tag})
+            }
+        }
+        location /get_lookup_size {
+            content_by_lua_block {
+                ngx.print(require("cjson").encode({
+                    metric_counter_dummy = metric_counter_dummy.lookup_size,
+                    metric_gauge_dummy = metric_gauge_dummy.lookup_size,
+                    metric_histogram_dummy = metric_histogram_dummy.lookup_size,
+                }))
             }
         }
     }

--- a/integration/test.go
+++ b/integration/test.go
@@ -288,7 +288,7 @@ func main() {
         if i == 999 {
             info := get_lookup_size(client)
             if info.Counter != 1000 || info.Gauge != 1000 || info.Histogram != 1000 {
-                log.Fatal("metric lookup table not updated")
+                log.Fatalf("metric lookup table not updated: %+v\n", info)
             }
         } else if i == 1000 {
             info := get_lookup_size(client)

--- a/integration/test.go
+++ b/integration/test.go
@@ -121,6 +121,9 @@ func get_lookup_size(client *http.Client) *LookupSizeInfo {
     if err != nil {
         log.Fatal(err)
     }
+    if resp.StatusCode != 200 {
+        log.Fatal("update metric failed")
+    }
     defer resp.Body.Close()
     body, err := ioutil.ReadAll(resp.Body)
     if err != nil {
@@ -283,18 +286,15 @@ func main() {
         if err != nil {
             log.Fatal(err)
         }
+        if resp.StatusCode != 200 {
+            log.Fatal("update metric failed")
+        }
         resp.Body.Close()
 
-        if i == 999 {
-            info := get_lookup_size(client)
-            if info.Counter != 1000 || info.Gauge != 1000 || info.Histogram != 1000 {
-                log.Fatalf("metric lookup table not updated: %+v\n", info)
-            }
-        } else if i == 1000 {
-            info := get_lookup_size(client)
-            if info.Counter != 1 || info.Gauge != 1 || info.Histogram != 1 {
-                log.Fatalf("metric lookup table not truncated: %+v\n", info)
-            }
+        info := get_lookup_size(client)
+        j := i % 1000 + 1;
+        if info.Counter != j || info.Gauge != j || info.Histogram != j {
+            log.Fatalf("metric lookup table not updated: %+v\n", info)
         }
     }
 

--- a/integration/test.go
+++ b/integration/test.go
@@ -118,10 +118,10 @@ func checkBucketBoundaries(mfs map[string]*dto.MetricFamily, metric string) erro
 
 func get_lookup_size(client *http.Client) *LookupSizeInfo {
     resp, err := client.Get("http://localhost:18003/get_lookup_size")
-    defer resp.Body.Close()
     if err != nil {
         log.Fatal(err)
     }
+    defer resp.Body.Close()
     body, err := ioutil.ReadAll(resp.Body)
     if err != nil {
         log.Fatal(err)

--- a/integration/test.sh
+++ b/integration/test.sh
@@ -23,7 +23,7 @@ function cleanup {
 cleanup
 trap cleanup EXIT
 
-docker run -d --name ${container_name} -p 18001:18001 -p 18002:18002 \
+docker run -d --name ${container_name} -p 18001:18001 -p 18002:18002 -p 18003:18003 \
   -v "${base_dir}/../:/nginx-lua-prometheus" ${image_name} \
   nginx -c /nginx-lua-prometheus/integration/nginx.conf
 


### PR DESCRIPTION
Each labels values combination would insert a new tree into the lookup table.
If that combinatioin is discarded later, and keep creating new combinations constantly, the lookup table would grow forever and cause memory leak.

Check apisix issue here as example: 

https://github.com/apache/apisix/issues/7949#issuecomment-1277311643

The simplest solutioin is to truncate the whole table when it exceeds a max limit, and the limit size is configurable.

Related to #150
