### PR TITLE
Improve histogram consistency

### DIFF
--- a/prometheus.lua
+++ b/prometheus.lua
@@ -607,6 +607,9 @@ local function observe(self, value, label_values)
   -- _sum metric.
   c:incr(keys[2], value)
 
+  -- the last bucket (le="Inf").
+  c:incr(keys[self.bucket_count+3], 1)
+
   local seen = false
   -- check in reverse order, otherwise we will always
   -- need to traverse the whole table.
@@ -618,8 +621,6 @@ local function observe(self, value, label_values)
       break
     end
   end
-  -- the last bucket (le="Inf").
-  c:incr(keys[self.bucket_count+3], 1)
 end
 
 -- Delete all metrics for a given gauge, counter or a histogram.


### PR DESCRIPTION
Hi, I have noticed, that some of our tooling has problems with histograms scraped from nginx.

The problem seems to be, that one worker processes collect() call, while another one is in the middle of updating histogram counters. This might result in situation, where the data contain higher count for some `le` values then for `le="+Inf"`.

Such inconsistency breaks all kinds of assumption that various tools might have. For us it has manifested by prometheus thinking that some counters produced by recorded rules were restarted (because `{le="+Inf"} - {le="0.1"}` was negative), which resulted in huge jumps in the metrics.

The proposed fix is rather simple, just set the infinity value before other buckets (which are already incremented in descending order). It actually still allows to return inconsistent values, but at least the common assumption of non-decreasing bucket values can't be broken.

Proper fix would probably require locking, as there is AFAIK no way to atomically increment multiple values in the shared dict.