### PR TITLE
 Reset metric name lookup table when another worker deletes a metric

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,6 +46,6 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.22
       - run: go get
       - run: ./test.sh

--- a/README.md
+++ b/README.md
@@ -106,12 +106,6 @@ section of nginx configuration.
   * `sync_interval` (number): sets the sync interval for per-worker counters and
     key index (in seconds). This sets the boundary on eventual consistency of
     counter metric increments, and metric resets/deletions. Defaults to 1.
-  * `lookup_max_size` (number): maximum size of a per-metric lookup table
-    maintained by each worker to cache full metric names. Defaults to 1000.
-    If you have metrics with extremely high cardinality and lots of available
-    RAM, you might want to increase this to avoid cache getting flushed too
-    often. Decreasing this makes sense if you have a very large number of
-    metrics or need to minimize memory usage of this library.
 
 Returns a `prometheus` object that should be used to register metrics.
 

--- a/README.md
+++ b/README.md
@@ -103,9 +103,9 @@ section of nginx configuration.
     metric names on output.
   * `error_metric_name` (string): Can be used to change the default name of
     error metric (see [Built-in metrics](#built-in-metrics) for details).
-  * `sync_interval` (number): sets per-worker counter sync interval in seconds.
-    This sets the boundary on eventual consistency of counter metrics. Defaults
-    to 1.
+  * `sync_interval` (number): sets the sync interval for per-worker counters and
+    key index (in seconds). This sets the boundary on eventual consistency of
+    counter metric increments, and metric resets/deletions. Defaults to 1.
   * `lookup_max_size` (number): maximum size of a per-metric lookup table
     maintained by each worker to cache full metric names. Defaults to 1000.
     If you have metrics with extremely high cardinality and lots of available

--- a/integration/go.mod
+++ b/integration/go.mod
@@ -1,6 +1,6 @@
 module github.com/knyar/nginx-lua-prometheus/integration
 
-go 1.14
+go 1.22
 
 require (
 	github.com/golang/protobuf v1.3.2
@@ -8,4 +8,10 @@ require (
 	github.com/kr/pretty v0.2.0
 	github.com/prometheus/client_model v0.2.0
 	github.com/prometheus/common v0.9.1
+)
+
+require (
+	github.com/kr/text v0.1.0 // indirect
+	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
+	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 )

--- a/integration/nginx.conf
+++ b/integration/nginx.conf
@@ -15,7 +15,9 @@ http {
     error_log stderr;
 
     init_worker_by_lua_block {
-        prometheus = require("prometheus").init("prometheus_metrics", {sync_interval=0.4})
+        prometheus = require("prometheus").init("prometheus_metrics", {sync_interval=0.1})
+
+        -- basic_test
         metric_requests = prometheus:counter("requests_total",
           "Number of HTTP requests", {"host", "path", "status"})
         metric_latency = prometheus:histogram("request_duration_seconds",
@@ -23,12 +25,20 @@ http {
           {0.08, 0.089991, 0.1, 0.2, 0.75, 1, 1.5, 3.123232001, 5, 15, 120, 350.5, 1500, 75000, 1500000})
         metric_connections = prometheus:gauge("connections",
           "Number of HTTP connections", {"state"})
+
+        -- reset_test
+        metric_gauge = prometheus:gauge("reset_test_gauge", "Sample gauge for reset test", {"label"})
     }
 
     server {
         listen 18000;
         server_name metrics;
 
+        location /health {
+            content_by_lua_block {
+                ngx.say("ok")
+            }
+        }
         location /metrics {
             content_by_lua_block {
                 metric_connections:set(ngx.var.connections_reading, {"reading"})
@@ -44,9 +54,10 @@ http {
         server_name basic_test;
 
         log_by_lua_block {
-            metric_requests:inc(1, {ngx.var.server_name, ngx.var.request_uri, ngx.var.status})
-            metric_latency:observe(tonumber(ngx.var.request_time),
-                                {ngx.var.request_uri})
+            if ngx.var.request_uri ~= "/health" then
+                metric_requests:inc(1, {ngx.var.server_name, ngx.var.request_uri, ngx.var.status})
+                metric_latency:observe(tonumber(ngx.var.request_time), {ngx.var.request_uri})
+            end
         }
 
         location /fast {
@@ -63,6 +74,34 @@ http {
         }
         location /error {
             return 500;
+        }
+        location /health {
+            content_by_lua_block {
+                ngx.say("ok")
+            }
+        }
+    }
+
+    server {
+        listen 18002;
+        server_name reset_test;
+
+        location /reset_gauge {
+            content_by_lua_block {
+                metric_gauge:reset()
+                ngx.say("ok")
+            }
+        }
+        location /set_gauge {
+            content_by_lua_block {
+                metric_gauge:set(tonumber(ngx.var.arg_metricvalue), {ngx.var.arg_labelvalue})
+                ngx.say("ok")
+            }
+        }
+        location /health {
+            content_by_lua_block {
+                ngx.say("ok")
+            }
         }
     }
 }

--- a/integration/nginx.conf
+++ b/integration/nginx.conf
@@ -15,31 +15,20 @@ http {
     error_log stderr;
 
     init_worker_by_lua_block {
-        prometheus = require("prometheus").init("prometheus_metrics",
-	  {sync_interval=0.4})
+        prometheus = require("prometheus").init("prometheus_metrics", {sync_interval=0.4})
         metric_requests = prometheus:counter("requests_total",
-          "Number of HTTP requests", {"host", "status"})
+          "Number of HTTP requests", {"host", "path", "status"})
         metric_latency = prometheus:histogram("request_duration_seconds",
-          "HTTP request latency", {"host"},
+          "HTTP request latency", {"path"},
           {0.08, 0.089991, 0.1, 0.2, 0.75, 1, 1.5, 3.123232001, 5, 15, 120, 350.5, 1500, 75000, 1500000})
         metric_connections = prometheus:gauge("connections",
           "Number of HTTP connections", {"state"})
     }
-    log_by_lua_block {
-        metric_requests:inc(1, {ngx.var.server_name, ngx.var.status})
-        metric_latency:observe(tonumber(ngx.var.request_time),
-                               {ngx.var.server_name})
-    }
 
     server {
-        listen 18001;
-        server_name fast;
-        root /nginx-lua-prometheus/integration/www;
-        index index.txt;
+        listen 18000;
+        server_name metrics;
 
-        location /error {
-            return 500;
-        }
         location /metrics {
             content_by_lua_block {
                 metric_connections:set(ngx.var.connections_reading, {"reading"})
@@ -49,15 +38,31 @@ http {
             }
         }
     }
+
     server {
-        listen 18002;
-        server_name slow;
-        location / {
+        listen 18001;
+        server_name basic_test;
+
+        log_by_lua_block {
+            metric_requests:inc(1, {ngx.var.server_name, ngx.var.request_uri, ngx.var.status})
+            metric_latency:observe(tonumber(ngx.var.request_time),
+                                {ngx.var.request_uri})
+        }
+
+        location /fast {
+            content_by_lua_block {
+                ngx.say("ok")
+            }
+        }
+        location /slow {
             content_by_lua_block {
                 -- sleep for 10-20ms.
                 ngx.sleep(0.01 + (0.01 * math.random()))
                 ngx.say("ok")
             }
+        }
+        location /error {
+            return 500;
         }
     }
 }

--- a/integration/test.go
+++ b/integration/test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"flag"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
 	"sync"
@@ -18,12 +19,15 @@ var (
 	testDuration = flag.Duration("duration", 10*time.Second, "duration of the test")
 )
 
+const healthURL = "http://localhost:18000/health"
 const metricsURL = "http://localhost:18000/metrics"
 
 type testRunner struct {
-	client *http.Client
-	tests  []testFunc
-	checks []checkFunc
+	ctx        context.Context
+	client     *http.Client
+	tests      []testFunc
+	checks     []checkFunc
+	healthURLs []string
 }
 
 type testFunc func() error
@@ -36,26 +40,39 @@ type testData struct {
 func main() {
 	flag.Parse()
 
-	// Use a custom http client with a lower idle connection timeout and a request timeout.
-	client := &http.Client{
-		Timeout:   500 * time.Millisecond,
-		Transport: &http.Transport{IdleConnTimeout: 400 * time.Millisecond},
-	}
-
-	// Wait for nginx to start.
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// Tests are expected to manage their duration themselves based on testDuration.
+	// Context timeout is longer than test duration to allow tests to complete
+	// without timing out.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Duration((*testDuration).Nanoseconds())*2)
 	defer cancel()
-	if err := waitFor(ctx, client, metricsURL); err != nil {
-		log.Fatal(err)
+	tr := &testRunner{
+		// Use a custom http client with a lower idle connection timeout and a request timeout.
+		client: &http.Client{
+			Timeout: 500 * time.Millisecond,
+			Transport: &http.Transport{
+				IdleConnTimeout: 400 * time.Millisecond,
+				MaxIdleConns:    100,
+				MaxConnsPerHost: 100,
+			},
+		},
+		ctx:        ctx,
+		healthURLs: []string{healthURL},
 	}
 
 	// Register tests.
-	t := &testRunner{client: client}
-	registerBasic(t)
+	registerBasicTest(tr)
+	registerResetTest(tr)
+
+	// Wait for all nginx servers to come up.
+	for _, url := range tr.healthURLs {
+		if err := tr.waitFor(url, 5*time.Second); err != nil {
+			log.Fatal(err)
+		}
+	}
 
 	// Run tests.
 	var wg sync.WaitGroup
-	for _, tt := range t.tests {
+	for _, tt := range tr.tests {
 		wg.Add(1)
 		go func(tt testFunc) {
 			if err := tt(); err != nil {
@@ -71,22 +88,12 @@ func main() {
 	time.Sleep(500 * time.Millisecond)
 
 	// Collect metrics.
-	resp, err := client.Get(metricsURL)
-	if err != nil {
-		log.Fatalf("Could not collect metrics: %v", err)
-	}
-	defer resp.Body.Close()
-
-	// Parse metrics.
-	var parser expfmt.TextParser
-	res := &testData{}
-	res.metrics, err = parser.TextToMetricFamilies(resp.Body)
-	if err != nil {
-		log.Fatalf("Could not parse metrics: %v", err)
+	res := &testData{
+		metrics: tr.mustGetMetrics(context.Background()),
 	}
 
 	// Run test checks.
-	for _, ch := range t.checks {
+	for _, ch := range tr.checks {
 		if err := ch(res); err != nil {
 			log.Fatal(err)
 		}
@@ -95,19 +102,67 @@ func main() {
 	log.Print("All ok")
 }
 
-func waitFor(ctx context.Context, c *http.Client, url string) error {
-	log.Printf("Waiting for %s...", url)
+func (tr *testRunner) mustGetMetrics(ctx context.Context) map[string]*dto.MetricFamily {
+	var res map[string]*dto.MetricFamily
+	tr.mustGetContext(ctx, metricsURL, func(r *http.Response) error {
+		if r.StatusCode != 200 {
+			return fmt.Errorf("expected response 200 got %v", r)
+		}
+		var parser expfmt.TextParser
+		var err error
+		res, err = parser.TextToMetricFamilies(r.Body)
+		return err
+	})
+	return res
+}
+
+func (tr *testRunner) getContext(ctx context.Context, url string, cb func(*http.Response) error) error {
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
 		return fmt.Errorf("creating request for %s: %v", url, err)
 	}
+	resp, err := tr.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("could not fetch URL %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if cb != nil {
+		return cb(resp)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("could not read HTTP response for %s: %v", url, err)
+	}
+	if resp.StatusCode != 200 || string(body) != "ok\n" {
+		return fmt.Errorf("unexpected response %q from %s; expected 'ok'", string(body), url)
+	}
+	return nil
+}
+
+func (tr *testRunner) mustGetContext(ctx context.Context, url string, cb func(*http.Response) error) {
+	if err := tr.getContext(ctx, url, cb); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (tr *testRunner) get(url string) error {
+	return tr.getContext(tr.ctx, url, nil)
+}
+
+func (tr *testRunner) mustGet(url string) {
+	if err := tr.get(url); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (tr *testRunner) waitFor(url string, timeout time.Duration) error {
+	ctx, cancel := context.WithTimeout(tr.ctx, timeout)
+	defer cancel()
+	log.Printf("Waiting for %s for %v...", url, timeout)
 	for {
-		resp, err := c.Do(req)
+		err := tr.getContext(ctx, url, nil)
 		if err == nil {
-			resp.Body.Close()
-			if resp.StatusCode == 200 {
-				return nil
-			}
+			return nil
 		}
 		if err := ctx.Err(); err != nil {
 			return err

--- a/integration/test.go
+++ b/integration/test.go
@@ -2,111 +2,35 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
-	"math"
-	"math/rand"
 	"net/http"
 	"sync"
 	"time"
 
-	"github.com/golang/protobuf/proto"
-	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/kr/pretty"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 )
 
 var (
 	testDuration = flag.Duration("duration", 10*time.Second, "duration of the test")
-	concurrency  = flag.Int("concurrency", 9, "number of concurrent http clients")
 )
 
-type requestType int
+const metricsURL = "http://localhost:18000/metrics"
 
-const (
-	reqFast requestType = iota
-	reqSlow
-	reqError
-)
-
-// There are three separate nginx endpoints:
-// - 'fast' simply returns "ok" with a 200 response code;
-// - 'slow' waits for 10ms and returns "ok" with a 200 response code;
-// - 'error' returns a 500.
-var urls = map[requestType]string{
-	reqFast:  "http://localhost:18001/",
-	reqSlow:  "http://localhost:18002/",
-	reqError: "http://localhost:18001/error",
+type testRunner struct {
+	client *http.Client
+	tests  []testFunc
+	checks []checkFunc
 }
 
-// Verify bucket boundaries. This should match the buckets defined in nginx.conf.
-var buckets = []float64{0.08, 0.089991, 0.1, 0.2, 0.75, 1, 1.5, 3.123232001, 5, 15, 120, 350.5, 1500, 75000, 1500000, math.Inf(1)}
+type testFunc func() error
+type checkFunc func(*testData) error
 
-// getHistogramSum returns the 'sum' value for a given histogram metric.
-func getHistogramSum(mfs map[string]*dto.MetricFamily, metric string, labels [][]string) float64 {
-	var lps []*dto.LabelPair
-	for _, lp := range labels {
-		lps = append(lps, &dto.LabelPair{Name: proto.String(lp[0]), Value: proto.String(lp[1])})
-	}
-
-	for _, mf := range mfs {
-		if *mf.Name == metric {
-			for _, m := range mf.Metric {
-				if cmp.Equal(m.Label, lps) {
-					return *m.Histogram.SampleSum
-				}
-			}
-		}
-	}
-	log.Fatalf("Metric %s with labels %v not found in %v", metric, lps, mfs)
-	return 0
-}
-
-// hasMetricFamily verifies that a given MetricFamily exists in a passed list of
-// metric families.
-func hasMetricFamily(mfs map[string]*dto.MetricFamily, want *dto.MetricFamily) error {
-	sortFn := func(x, y interface{}) bool { return pretty.Sprint(x) < pretty.Sprint(y) }
-	for _, mf := range mfs {
-		if *mf.Name == *want.Name {
-			if diff := cmp.Diff(want, mf, cmpopts.SortSlices(sortFn)); diff != "" {
-				return fmt.Errorf("Unexpected metric family %v (-want +got):\n%s", mf.Name, diff)
-			}
-			return nil
-		}
-	}
-	return fmt.Errorf("Metric family %v not found in %v", want, mfs)
-}
-
-// checkBucketBoundaries verifies bucket boundary values.
-func checkBucketBoundaries(mfs map[string]*dto.MetricFamily, metric string) error {
-	matched := false
-	for _, mf := range mfs {
-		if *mf.Name != metric {
-			continue
-		}
-		matched = true
-		for _, m := range mf.Metric {
-			if len(m.Histogram.Bucket) != len(buckets) {
-				return fmt.Errorf("expected %d buckets but got %d: %v", len(buckets), len(m.Histogram.Bucket), m.Histogram.Bucket)
-			}
-			for idx, b := range m.Histogram.Bucket {
-				tolerance := 0.00001
-				if diff := math.Abs(*b.UpperBound - buckets[idx]); diff > tolerance {
-					return fmt.Errorf("unexpected value for bucket #%d; want %f got %f", idx, buckets[idx], *b.UpperBound)
-				}
-			}
-		}
-	}
-
-	if !matched {
-		return fmt.Errorf("could not find metric %s", metric)
-	}
-
-	return nil
+type testData struct {
+	metrics map[string]*dto.MetricFamily
 }
 
 func main() {
@@ -118,136 +42,76 @@ func main() {
 		Transport: &http.Transport{IdleConnTimeout: 400 * time.Millisecond},
 	}
 
-	log.Printf("Starting the test with %d concurrent clients", *concurrency)
+	// Wait for nginx to start.
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := waitFor(ctx, client, metricsURL); err != nil {
+		log.Fatal(err)
+	}
+
+	// Register tests.
+	t := &testRunner{client: client}
+	registerBasic(t)
+
+	// Run tests.
 	var wg sync.WaitGroup
-	results := make(chan map[requestType]int64, *concurrency)
-	for i := 1; i <= *concurrency; i++ {
+	for _, tt := range t.tests {
 		wg.Add(1)
-		go func() {
-			result := make(map[requestType]int64)
-			for start := time.Now(); time.Since(start) < *testDuration; {
-				t := reqFast
-				r := rand.Intn(100)
-				if r < 10 {
-					// 10% are slow requests
-					t = reqSlow
-				} else if r < 15 {
-					// 5% are errors
-					t = reqError
-				}
-				resp, err := client.Get(urls[t])
-				if err != nil {
-					log.Fatalf("Could not fetch URL %s: %v", urls[t], err)
-				}
-				body, err := ioutil.ReadAll(resp.Body)
-				if err != nil {
-					log.Fatalf("Could not read HTTP response for %s: %v", urls[t], err)
-				}
-				resp.Body.Close()
-				if t != reqError && string(body) != "ok\n" {
-					log.Fatalf("Unexpected response %q from %s; expected 'ok'", string(body), urls[t])
-				}
-				result[t]++
+		go func(tt testFunc) {
+			if err := tt(); err != nil {
+				log.Fatal(err)
 			}
-			results <- result
 			wg.Done()
-		}()
+		}(tt)
 	}
 	wg.Wait()
-	close(results)
-
-	var fast, slow, errors int64
-	for r := range results {
-		fast += r[reqFast]
-		slow += r[reqSlow]
-		errors += r[reqError]
-	}
-	total := fast + slow + errors
-	log.Printf("Sent %d requests (%d fast, %d slow, %d errors)", total, fast, slow, errors)
 
 	// Sleep for 500ms before collecting metrics. This is to ensure that all HTTP connections
 	// to nginx get closed, and to allow for some eventual consistency in nginx-lua-prometheus.
 	time.Sleep(500 * time.Millisecond)
 
-	resp, err := client.Get("http://localhost:18001/metrics")
+	// Collect metrics.
+	resp, err := client.Get(metricsURL)
 	if err != nil {
 		log.Fatalf("Could not collect metrics: %v", err)
 	}
 	defer resp.Body.Close()
 
+	// Parse metrics.
 	var parser expfmt.TextParser
-	mfs, err := parser.TextToMetricFamilies(resp.Body)
+	res := &testData{}
+	res.metrics, err = parser.TextToMetricFamilies(resp.Body)
 	if err != nil {
 		log.Fatalf("Could not parse metrics: %v", err)
 	}
 
-	// We expect all fast requests to take less than 1 second.
-	if v := getHistogramSum(mfs, "request_duration_seconds", [][]string{{"host", "fast"}}); v > 1 {
-		log.Fatalf("Total time to process all fast request is %f; expected <= 1", v)
-	}
-
-	minSlowSeconds := float64(slow) * 0.01 // at least 10ms per request
-	if v := getHistogramSum(mfs, "request_duration_seconds", [][]string{{"host", "slow"}}); v <= minSlowSeconds {
-		log.Fatalf("Total time to process all fast request is %f; expected > %f", v, minSlowSeconds)
-	}
-
-	expected := []*dto.MetricFamily{
-		{
-			// There should be no errors reported by the library.
-			Name:   proto.String("nginx_metric_errors_total"),
-			Help:   proto.String("Number of nginx-lua-prometheus errors"),
-			Type:   dto.MetricType_COUNTER.Enum(),
-			Metric: []*dto.Metric{{Counter: &dto.Counter{Value: proto.Float64(0)}}},
-		},
-		{
-			Name: proto.String("requests_total"),
-			Help: proto.String("Number of HTTP requests"),
-			Type: dto.MetricType_COUNTER.Enum(),
-			Metric: []*dto.Metric{
-				{Label: []*dto.LabelPair{
-					{Name: proto.String("host"), Value: proto.String("fast")},
-					{Name: proto.String("status"), Value: proto.String("200")},
-				}, Counter: &dto.Counter{Value: proto.Float64(float64(fast))}},
-				{Label: []*dto.LabelPair{
-					{Name: proto.String("host"), Value: proto.String("slow")},
-					{Name: proto.String("status"), Value: proto.String("200")},
-				}, Counter: &dto.Counter{Value: proto.Float64(float64(slow))}},
-				{Label: []*dto.LabelPair{
-					{Name: proto.String("host"), Value: proto.String("fast")},
-					{Name: proto.String("status"), Value: proto.String("500")},
-				}, Counter: &dto.Counter{Value: proto.Float64(float64(errors))}},
-			},
-		},
-		{
-			// After all tests are complete there should only be a single HTTP
-			// connection, which should be in 'writing' state (the connection
-			// used by nginx to return metric values).
-			Name: proto.String("connections"),
-			Help: proto.String("Number of HTTP connections"),
-			Type: dto.MetricType_GAUGE.Enum(),
-			Metric: []*dto.Metric{
-				{Label: []*dto.LabelPair{
-					{Name: proto.String("state"), Value: proto.String("reading")},
-				}, Gauge: &dto.Gauge{Value: proto.Float64(float64(0))}},
-				{Label: []*dto.LabelPair{
-					{Name: proto.String("state"), Value: proto.String("waiting")},
-				}, Gauge: &dto.Gauge{Value: proto.Float64(float64(0))}},
-				{Label: []*dto.LabelPair{
-					{Name: proto.String("state"), Value: proto.String("writing")},
-				}, Gauge: &dto.Gauge{Value: proto.Float64(float64(1))}},
-			},
-		},
-	}
-
-	for _, mf := range expected {
-		if err := hasMetricFamily(mfs, mf); err != nil {
+	// Run test checks.
+	for _, ch := range t.checks {
+		if err := ch(res); err != nil {
 			log.Fatal(err)
 		}
 	}
 
-	if err := checkBucketBoundaries(mfs, "request_duration_seconds"); err != nil {
-		log.Fatal(err)
-	}
-
 	log.Print("All ok")
+}
+
+func waitFor(ctx context.Context, c *http.Client, url string) error {
+	log.Printf("Waiting for %s...", url)
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return fmt.Errorf("creating request for %s: %v", url, err)
+	}
+	for {
+		resp, err := c.Do(req)
+		if err == nil {
+			resp.Body.Close()
+			if resp.StatusCode == 200 {
+				return nil
+			}
+		}
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
 }

--- a/integration/test.sh
+++ b/integration/test.sh
@@ -23,12 +23,12 @@ function cleanup {
 cleanup
 trap cleanup EXIT
 
-docker run -d --name ${container_name} -p 18001:18001 -p 18002:18002 \
+docker run -d --name ${container_name} -p 18000-18001:18000-18001 \
   -v "${base_dir}/../:/nginx-lua-prometheus" ${image_name} \
   nginx -c /nginx-lua-prometheus/integration/nginx.conf
 
 RC=0
-go run test.go || RC=$?
+go run . || RC=$?
 
 nginx_logs 2>&1 | tail -30
 

--- a/integration/test.sh
+++ b/integration/test.sh
@@ -23,7 +23,7 @@ function cleanup {
 cleanup
 trap cleanup EXIT
 
-docker run -d --name ${container_name} -p 18000-18001:18000-18001 \
+docker run -d --name ${container_name} -p 18000-18010:18000-18010 \
   -v "${base_dir}/../:/nginx-lua-prometheus" ${image_name} \
   nginx -c /nginx-lua-prometheus/integration/nginx.conf
 

--- a/integration/test_basic.go
+++ b/integration/test_basic.go
@@ -1,0 +1,231 @@
+// This is a simple integration test for nginx-lua-prometheus.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"math"
+	"math/rand"
+	"sync"
+	"time"
+
+	"github.com/golang/protobuf/proto"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/kr/pretty"
+	dto "github.com/prometheus/client_model/go"
+)
+
+var (
+	concurrency = flag.Int("concurrency", 9, "number of concurrent http clients")
+)
+
+type requestType int
+
+const (
+	reqFast requestType = iota
+	reqSlow
+	reqError
+)
+
+// There are three separate nginx endpoints:
+// - 'fast' simply returns "ok" with a 200 response code;
+// - 'slow' waits for 10ms and returns "ok" with a 200 response code;
+// - 'error' returns a 500.
+var urls = map[requestType]string{
+	reqFast:  "http://localhost:18001/fast",
+	reqSlow:  "http://localhost:18001/slow",
+	reqError: "http://localhost:18001/error",
+}
+
+// Verify bucket boundaries. This should match the buckets defined in nginx.conf.
+var buckets = []float64{0.08, 0.089991, 0.1, 0.2, 0.75, 1, 1.5, 3.123232001, 5, 15, 120, 350.5, 1500, 75000, 1500000, math.Inf(1)}
+
+func registerBasic(tr *testRunner) {
+	results := make(chan map[requestType]int64, *concurrency)
+	tr.tests = append(tr.tests, func() error {
+		log.Printf("Running basic test with %d concurrent clients for %v", *concurrency, *testDuration)
+		var wg sync.WaitGroup
+		for i := 1; i <= *concurrency; i++ {
+			wg.Add(1)
+			go func() {
+				result := make(map[requestType]int64)
+				for start := time.Now(); time.Since(start) < *testDuration; {
+					t := reqFast
+					r := rand.Intn(100)
+					if r < 10 {
+						// 10% are slow requests
+						t = reqSlow
+					} else if r < 15 {
+						// 5% are errors
+						t = reqError
+					}
+					resp, err := tr.client.Get(urls[t])
+					if err != nil {
+						log.Fatalf("Could not fetch URL %s: %v", urls[t], err)
+					}
+					body, err := io.ReadAll(resp.Body)
+					if err != nil {
+						log.Fatalf("Could not read HTTP response for %s: %v", urls[t], err)
+					}
+					resp.Body.Close()
+					if t != reqError && string(body) != "ok\n" {
+						log.Fatalf("Unexpected response %q from %s; expected 'ok'", string(body), urls[t])
+					}
+					result[t]++
+				}
+				results <- result
+				wg.Done()
+			}()
+		}
+		wg.Wait()
+		close(results)
+		return nil
+	})
+
+	tr.checks = append(tr.checks, func(r *testData) error {
+		mfs := r.metrics
+		var fast, slow, errors int64
+		for r := range results {
+			fast += r[reqFast]
+			slow += r[reqSlow]
+			errors += r[reqError]
+		}
+		total := fast + slow + errors
+		log.Printf("Sent %d requests (%d fast, %d slow, %d errors)", total, fast, slow, errors)
+
+		// We expect all fast requests to take less than 1 second.
+		if v := getHistogramSum(mfs, "request_duration_seconds", [][]string{{"path", "/fast"}}); v > 1 {
+			return fmt.Errorf("total time to process all fast request is %f; expected <= 1", v)
+		}
+
+		minSlowSeconds := float64(slow) * 0.01 // at least 10ms per request
+		if v := getHistogramSum(mfs, "request_duration_seconds", [][]string{{"path", "/slow"}}); v <= minSlowSeconds {
+			return fmt.Errorf("total time to process all fast request is %f; expected > %f", v, minSlowSeconds)
+		}
+
+		expected := []*dto.MetricFamily{
+			{
+				// There should be no errors reported by the library.
+				Name:   proto.String("nginx_metric_errors_total"),
+				Help:   proto.String("Number of nginx-lua-prometheus errors"),
+				Type:   dto.MetricType_COUNTER.Enum(),
+				Metric: []*dto.Metric{{Counter: &dto.Counter{Value: proto.Float64(0)}}},
+			},
+			{
+				Name: proto.String("requests_total"),
+				Help: proto.String("Number of HTTP requests"),
+				Type: dto.MetricType_COUNTER.Enum(),
+				Metric: []*dto.Metric{
+					{Label: []*dto.LabelPair{
+						{Name: proto.String("host"), Value: proto.String("basic_test")},
+						{Name: proto.String("path"), Value: proto.String("/fast")},
+						{Name: proto.String("status"), Value: proto.String("200")},
+					}, Counter: &dto.Counter{Value: proto.Float64(float64(fast))}},
+					{Label: []*dto.LabelPair{
+						{Name: proto.String("host"), Value: proto.String("basic_test")},
+						{Name: proto.String("path"), Value: proto.String("/slow")},
+						{Name: proto.String("status"), Value: proto.String("200")},
+					}, Counter: &dto.Counter{Value: proto.Float64(float64(slow))}},
+					{Label: []*dto.LabelPair{
+						{Name: proto.String("host"), Value: proto.String("basic_test")},
+						{Name: proto.String("path"), Value: proto.String("/error")},
+						{Name: proto.String("status"), Value: proto.String("500")},
+					}, Counter: &dto.Counter{Value: proto.Float64(float64(errors))}},
+				},
+			},
+			{
+				// After all tests are complete there should only be a single HTTP
+				// connection, which should be in 'writing' state (the connection
+				// used by nginx to return metric values).
+				Name: proto.String("connections"),
+				Help: proto.String("Number of HTTP connections"),
+				Type: dto.MetricType_GAUGE.Enum(),
+				Metric: []*dto.Metric{
+					{Label: []*dto.LabelPair{
+						{Name: proto.String("state"), Value: proto.String("reading")},
+					}, Gauge: &dto.Gauge{Value: proto.Float64(float64(0))}},
+					{Label: []*dto.LabelPair{
+						{Name: proto.String("state"), Value: proto.String("waiting")},
+					}, Gauge: &dto.Gauge{Value: proto.Float64(float64(0))}},
+					{Label: []*dto.LabelPair{
+						{Name: proto.String("state"), Value: proto.String("writing")},
+					}, Gauge: &dto.Gauge{Value: proto.Float64(float64(1))}},
+				},
+			},
+		}
+
+		for _, mf := range expected {
+			if err := hasMetricFamily(mfs, mf); err != nil {
+				return err
+			}
+		}
+
+		return checkBucketBoundaries(mfs, "request_duration_seconds")
+	})
+}
+
+// getHistogramSum returns the 'sum' value for a given histogram metric.
+func getHistogramSum(mfs map[string]*dto.MetricFamily, metric string, labels [][]string) float64 {
+	var lps []*dto.LabelPair
+	for _, lp := range labels {
+		lps = append(lps, &dto.LabelPair{Name: proto.String(lp[0]), Value: proto.String(lp[1])})
+	}
+
+	for _, mf := range mfs {
+		if *mf.Name == metric {
+			for _, m := range mf.Metric {
+				if cmp.Equal(m.Label, lps) {
+					return *m.Histogram.SampleSum
+				}
+			}
+		}
+	}
+	log.Fatalf("Metric %s with labels %v not found in %v", metric, lps, mfs)
+	return 0
+}
+
+// hasMetricFamily verifies that a given MetricFamily exists in a passed list of
+// metric families.
+func hasMetricFamily(mfs map[string]*dto.MetricFamily, want *dto.MetricFamily) error {
+	sortFn := func(x, y interface{}) bool { return pretty.Sprint(x) < pretty.Sprint(y) }
+	for _, mf := range mfs {
+		if *mf.Name == *want.Name {
+			if diff := cmp.Diff(want, mf, cmpopts.SortSlices(sortFn)); diff != "" {
+				return fmt.Errorf("unexpected metric family %v (-want +got):\n%s", mf.Name, diff)
+			}
+			return nil
+		}
+	}
+	return fmt.Errorf("metric family %v not found in %v", want, mfs)
+}
+
+// checkBucketBoundaries verifies bucket boundary values.
+func checkBucketBoundaries(mfs map[string]*dto.MetricFamily, metric string) error {
+	matched := false
+	for _, mf := range mfs {
+		if *mf.Name != metric {
+			continue
+		}
+		matched = true
+		for _, m := range mf.Metric {
+			if len(m.Histogram.Bucket) != len(buckets) {
+				return fmt.Errorf("expected %d buckets but got %d: %v", len(buckets), len(m.Histogram.Bucket), m.Histogram.Bucket)
+			}
+			for idx, b := range m.Histogram.Bucket {
+				tolerance := 0.00001
+				if diff := math.Abs(*b.UpperBound - buckets[idx]); diff > tolerance {
+					return fmt.Errorf("unexpected value for bucket #%d; want %f got %f", idx, buckets[idx], *b.UpperBound)
+				}
+			}
+		}
+	}
+
+	if !matched {
+		return fmt.Errorf("could not find metric %s", metric)
+	}
+
+	return nil
+}

--- a/integration/test_reset.go
+++ b/integration/test_reset.go
@@ -1,0 +1,89 @@
+// This is a simple integration test for nginx-lua-prometheus.
+package main
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"sync"
+	"time"
+
+	dto "github.com/prometheus/client_model/go"
+)
+
+func registerResetTest(tr *testRunner) {
+	tr.healthURLs = append(tr.healthURLs, "http://localhost:18002/health")
+
+	const setURL = "http://localhost:18002/set_gauge"
+	const resetURL = "http://localhost:18002/reset_gauge"
+	const metricName = "reset_test_gauge"
+	tr.tests = append(tr.tests, func() error {
+		log.Printf("Running reset test with %d concurrent clients for %v", *concurrency, *testDuration)
+		var wg sync.WaitGroup
+		var mu sync.RWMutex
+		for i := 1; i <= *concurrency; i++ {
+			wg.Add(1)
+			go func(i int) {
+				labelValue := fmt.Sprintf("client%d", i)
+				setUrl := func(value int) string {
+					return fmt.Sprintf("%s?labelvalue=%s&metricvalue=%d", setURL, labelValue, value)
+				}
+				// Check that returned metrics contain a value for this worker.
+				// If wantValue is 0, it means the metric should not exist at all.
+				checkValue := func(mfs map[string]*dto.MetricFamily, wantValue int) {
+					for _, mf := range mfs {
+						if mf.GetName() != metricName {
+							continue
+						}
+						if wantValue == 0 {
+							log.Fatalf("client %d: metric %s exists while it should not; %+v", i, metricName, mf)
+						}
+						for _, m := range mf.Metric {
+							if len(m.Label) != 1 {
+								log.Fatalf("client %d: expected metric %s to have 1 label, got %+v", i, metricName, m)
+							}
+							if m.Label[0].GetValue() != labelValue {
+								continue
+							}
+							if m.GetGauge().GetValue() != float64(wantValue) {
+								log.Fatalf("client %d: expected metric %s to have value of %d, got %+v", i, metricName, wantValue, m)
+							}
+							return
+						}
+						log.Fatalf("client %d: metric %s does not have label %s while it should; %+v", i, metricName, labelValue, mf)
+					}
+					if wantValue != 0 {
+						log.Fatalf("client %d: metric %s not found in %+v", i, metricName, mfs)
+					}
+				}
+				for start := time.Now(); time.Since(start) < *testDuration; {
+					// Call the URL that sets a label value and confirm that it
+					// exists in the returned metrics.
+					value := 1 + rand.Intn(9000)
+					mu.RLock()
+					tr.mustGet(setUrl(value))
+					metrics := tr.mustGetMetrics(tr.ctx)
+					checkValue(metrics, value)
+					mu.RUnlock()
+
+					// Occasionally, reset the metric and confirm that it does
+					// not get returned. A mutex ensures that no other clients
+					// attempt to change or reset the gauge at the same time.
+					if rand.Intn(100) < 5 {
+						mu.Lock()
+						tr.mustGet(resetURL)
+						metrics := tr.mustGetMetrics(tr.ctx)
+						checkValue(metrics, 0)
+						// Wait for slightly longer than sync_interval to ensure that
+						// metric reset gets propagated to all workers.
+						time.Sleep(105 * time.Millisecond)
+						mu.Unlock()
+					}
+				}
+				wg.Done()
+			}(i)
+		}
+		wg.Wait()
+		return nil
+	})
+}

--- a/prometheus_test.lua
+++ b/prometheus_test.lua
@@ -849,44 +849,6 @@ function TestKeyIndex:testSync()
   luaunit.assertEquals(self.last_deleted_key, "key2")
 end
 
-function TestPrometheus:testLookupMaxSize()
-  local c = self.p:counter("testc", "Counter", {"tag"})
-  local g = self.p:gauge("testg", "Gauge", {"tag"})
-  local h = self.p:histogram("testh", "Histogram", {"tag"})
-
-  luaunit.assertEquals(c.lookup_size, 0)
-  luaunit.assertEquals(g.lookup_size, 0)
-  luaunit.assertEquals(h.lookup_size, 0)
-  luaunit.assertEquals(c.lookup_max_size, 1000)
-  luaunit.assertEquals(g.lookup_max_size, 1000)
-  luaunit.assertEquals(h.lookup_max_size, 1000)
-
-  for _, max_size in ipairs({10, 17, 101}) do
-    local p1 = require('prometheus').init("metrics",
-      {lookup_max_size=max_size})
-    local c1 = p1:counter("testc1", "Counter", {"tag"})
-    local g1 = p1:gauge("testg1", "Gauge", {"tag"})
-    local h1 = p1:histogram("testh1", "Histogram", {"tag"})
-
-    luaunit.assertEquals(p1.lookup_max_size, max_size)
-    luaunit.assertEquals(c1.lookup_max_size, max_size)
-    luaunit.assertEquals(g1.lookup_max_size, max_size)
-    luaunit.assertEquals(h1.lookup_max_size, max_size)
-
-    for i = 0, max_size * 2.1, 1 do
-      c1:inc(1, {tostring(i)})
-      g1:set(3, {tostring(i)})
-      h1:observe(50, {tostring(i)})
-
-      luaunit.assertEquals(c1.lookup_size, (i % max_size)+1)
-      luaunit.assertEquals(g1.lookup_size, (i % max_size)+1)
-      luaunit.assertEquals(h1.lookup_size, (i % max_size)+1)
-    end
-  end
-
-  luaunit.assertEquals(self.dict:get("nginx_metric_errors_total"), 0)
-end
-
 function TestPrometheus.testPrintfTable()
   local p = require('prometheus')
   luaunit.assertEquals(p._table_to_string(nil), "nil")


### PR DESCRIPTION
A few commits here that are easier to review individually, adding a test to reproduce #168 and fixing the issue by emtying the per-metric lookup table every time a metric is deleted by one of the other nginx workers. (cc @Ashion who reported this)

Since we already have a way to propagate metric key deletion to other workers via KeyIndex, I am piggy-backing on the same mechanism to trigger lookup table cleanup. (cc @dolik-rce who implemented the KeyIndex)

This also addresses the issue of unbounded memory growth when there is metric churn (#151), so I am removing the static lookup table size limit that was introduced as a mitigation. (cc @kingluo who reported that memory leak issue)

I will wait for a few days before merging this just in case someone has any feedback.

Fixes #168