### PR TITLE
allow 0 value as a valid value for set() and observe()

### DIFF
--- a/prometheus.lua
+++ b/prometheus.lua
@@ -549,7 +549,7 @@ end
 --   value: numeric value.
 --   label_values: a list of label values, in the same order as label keys.
 local function set(self, value, label_values)
-  if not value then
+  if tonumber(value) == nil then
     self._log_error("No value passed for " .. self.name)
     return
   end
@@ -573,7 +573,7 @@ end
 --   value: numeric value to record. Should be defined.
 --   label_values: a list of label values, in the same order as label keys.
 local function observe(self, value, label_values)
-  if not value then
+  if tonumber(value) == nil then
     self._log_error("No value passed for " .. self.name)
     return
   end


### PR DESCRIPTION
This PR address usage of observe() and set() with a 0 value.

In my case, I get 0 with No value passed for nginx_upstream_http_connect_duration_seconds while observing tonumber(ngx.var.upstream_connect_time)