### PR TITLE
Install libreadline-dev before running tests in GH Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
-      - run: sudo apt install libpcre2-dev
+      - run: sudo apt install libpcre2-dev libreadline-dev
       - run: pip install hererocks
       # Install latest LuaRocks version plus the Lua version for this build job
       # into 'here' subdirectory.


### PR DESCRIPTION
Seems to be necessary following their move to Ubuntu 24.04: https://github.com/actions/runner-images/issues/10636